### PR TITLE
Initial import from JHU/APL repositories

### DIFF
--- a/.github/workflows/devel-push.yml
+++ b/.github/workflows/devel-push.yml
@@ -262,9 +262,6 @@ jobs:
           apt: libkrb5-dev llvm-${{ env.LLVM_VERSION }}
           brew: llvm@${{ env.LLVM_VERSION }}
 
-      - name: Generate test certificates
-        run: sh gen_test_certs.sh
-
       - name: Run tests
         if: matrix.os == 'ubuntu-24.04'
         uses: actions-rs/cargo@v1
@@ -292,7 +289,7 @@ jobs:
           for f in `find src -type f -regex ".*\.rs"`; do SRCS+="$f "; done
           TESTBINS=""
           CRATE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | cut -f2 -d"/")
-          for f in `find target/debug/deps -type f -regex "target/debug/deps/$CRATE_NAME\-[0-9a-f]*$"`; do TESTBINS+="$f "; done
+          for f in `find target/debug/deps -type f -regex "target/debug/deps/${CRATE_NAME//-/_}\-[0-9a-f]*$"`; do TESTBINS+="$f "; done
           llvm-cov-${{ env.LLVM_VERSION }} export --format=lcov --ignore-filename-regex="$HOME/.cargo/*|/rustc/" --instr-profile=target/coverage/coverage.profdata `echo $TESTBINS` `echo $SRCS` > target/coverage/${{ runner.os }}-coverage.lcov
 
       - name: Generate coverage report
@@ -304,7 +301,7 @@ jobs:
           for f in `find src -type f -regex ".*\.rs"`; do SRCS+="$f "; done
           TESTBINS=""
           CRATE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | cut -f2 -d"/")
-          for f in `find target/debug/deps -type f -regex "target/debug/deps/$CRATE_NAME\-[0-9a-f]*$"`; do TESTBINS+="$f "; done
+          for f in `find target/debug/deps -type f -regex "target/debug/deps/${CRATE_NAME//-/_}\-[0-9a-f]*$"`; do TESTBINS+="$f "; done
           /opt/homebrew/bin/llvm-cov export --format=lcov --ignore-filename-regex="$HOME/.cargo/*|/rustc/" --instr-profile=target/coverage/coverage.profdata `echo $TESTBINS` `echo $SRCS` > target/coverage/${{ runner.os }}-coverage.lcov
 
       - name: Upload coverage data
@@ -349,9 +346,6 @@ jobs:
         uses: ConorMacBride/install-package@v1
         with:
           apt: libkrb5-dev
-
-      - name: Generate test certificates
-        run: sh gen_test_certs.sh
 
       - name: Run tests
         if: matrix.os == 'ubuntu-24.04'

--- a/.github/workflows/devel-push.yml
+++ b/.github/workflows/devel-push.yml
@@ -419,7 +419,7 @@ jobs:
       - name: Patch documentation
         run: |
           CRATE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | cut -f2 -d"/")
-          echo "<meta http-equiv=\"refresh\" content=\"0; url=$CRATE_NAME/index.html\">" > target/doc/index.html
+          echo "<meta http-equiv=\"refresh\" content=\"0; url=${CRATE_NAME//-/_}/index.html\">" > target/doc/index.html
           touch target/doc/.nojekyll
 
       - name: Remove lockfile

--- a/.github/workflows/devel-push.yml
+++ b/.github/workflows/devel-push.yml
@@ -197,9 +197,37 @@ jobs:
       - name: Check license header
         uses: apache/skywalking-eyes/header@main
 
+  dep-branches:
+    name: Constellation dependency branch check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Check branches for constellation dependencies
+        run: |
+          if `cargo tree | grep github.com/constellation-system | sed  's/[^?]*?//' | sed 's/#.*//' | sed 's/branch=//' | grep -Evq "^devel$"`; then
+            echo "Constellation depnedencies not on devel branch:"
+            cargo tree | grep github.com/constellation-system
+            exit 1
+          fi
+
   test-debug:
     name: Run tests with debug build
-    needs: [format, check, lint, audit, license]
+    needs: [format, check, lint, audit, license, dep-branches]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -288,7 +316,7 @@ jobs:
 
   test-release:
     name: Run tests with release build
-    needs: [format, check, lint, audit, license]
+    needs: [format, check, lint, audit, license, dep-branches]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/devel-push.yml
+++ b/.github/workflows/devel-push.yml
@@ -1,0 +1,435 @@
+name: Development branch builder
+
+run-name: Push to devel by ${{ github.actor }}
+
+env:
+  LINT_FLAGS: -W clippy::all -W clippy::pedantic -W clippy::cargo
+  RUST_TOOLCHAIN: 'nightly-2024-07-21'
+  LLVM_VERSION: 18
+
+on:
+  push:
+    branches:
+      - 'devel'
+
+permissions: {}
+
+jobs:
+  format:
+    name: Format check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+          components: rustfmt
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Check formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check --verbose
+
+  check:
+    name: Compile warnings
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Check for compile warnings
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  lint:
+    name: Lint check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+          components: clippy
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Lint check
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: -- ${{ env.LINT_PARAMS }}
+
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Install cargo-audit
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-audit --locked
+
+      - name: Audit code
+        uses: actions-rs/cargo@v1
+        with:
+          command: audit
+
+  license:
+    name: License header check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Check license header
+        uses: apache/skywalking-eyes/header@main
+
+  test-debug:
+    name: Run tests with debug build
+    needs: [format, check, lint, audit, license]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, macos-14]
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Install GSSAPI development and LLVM-${{ env.LLVM_VERSION }}
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev llvm-${{ env.LLVM_VERSION }}
+          brew: llvm@${{ env.LLVM_VERSION }}
+
+      - name: Generate test certificates
+        run: sh gen_test_certs.sh
+
+      - name: Run tests
+        if: matrix.os == 'ubuntu-24.04'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+        env:
+          RUSTFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Clink-dead-code'
+          LLVM_PROFILE_FILE: 'target/coverage/profile_%m_%p.profraw'
+
+      - name: Run tests
+        if: matrix.os == 'macos-14'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features log,openssl,unix
+        env:
+          RUSTFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Clink-dead-code --remap-path-prefix=${{ github.workspace }}='
+          LLVM_PROFILE_FILE: 'target/coverage/${{ runner.os }}_%m_%p.profraw'
+
+      - name: Generate coverage report
+        if: matrix.os == 'ubuntu-24.04'
+        run: |
+          llvm-profdata-${{ env.LLVM_VERSION }} merge --sparse target/coverage/*.profraw -o target/coverage/coverage.profdata
+          SRCS=""
+          for f in `find src -type f -regex ".*\.rs"`; do SRCS+="$f "; done
+          TESTBINS=""
+          CRATE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | cut -f2 -d"/")
+          for f in `find target/debug/deps -type f -regex "target/debug/deps/$CRATE_NAME\-[0-9a-f]*$"`; do TESTBINS+="$f "; done
+          llvm-cov-${{ env.LLVM_VERSION }} export --format=lcov --ignore-filename-regex="$HOME/.cargo/*|/rustc/" --instr-profile=target/coverage/coverage.profdata `echo $TESTBINS` `echo $SRCS` > target/coverage/${{ runner.os }}-coverage.lcov
+
+      - name: Generate coverage report
+        if: matrix.os == 'macos-14'
+        run: |
+          /opt/homebrew/bin/brew link llvm@18
+          /opt/homebrew/bin/llvm-profdata merge --sparse target/coverage/*.profraw -o target/coverage/coverage.profdata
+          SRCS=""
+          for f in `find src -type f -regex ".*\.rs"`; do SRCS+="$f "; done
+          TESTBINS=""
+          CRATE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | cut -f2 -d"/")
+          for f in `find target/debug/deps -type f -regex "target/debug/deps/$CRATE_NAME\-[0-9a-f]*$"`; do TESTBINS+="$f "; done
+          /opt/homebrew/bin/llvm-cov export --format=lcov --ignore-filename-regex="$HOME/.cargo/*|/rustc/" --instr-profile=target/coverage/coverage.profdata `echo $TESTBINS` `echo $SRCS` > target/coverage/${{ runner.os }}-coverage.lcov
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}
+          path: target/coverage/${{ runner.os }}-coverage.lcov
+          if-no-files-found: error
+
+  test-release:
+    name: Run tests with release build
+    needs: [format, check, lint, audit, license]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, macos-14]
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Generate test certificates
+        run: sh gen_test_certs.sh
+
+      - name: Run tests
+        if: matrix.os == 'ubuntu-24.04'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release
+
+      - name: Run tests
+        if: matrix.os == 'macos-14'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --no-default-features --features log,openssl,unix
+
+  pages:
+    name: Generate pages content
+    needs: [test-debug, test-release]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev lcov
+
+      - name: Download ubuntu-24.04 coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-ubuntu-24.04
+
+      - name: Download macos-14 coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-macos-14
+
+      - name: Merge lcov files
+        run: lcov -a Linux-coverage.lcov -t linux -a macOS-coverage.lcov -t macos -o coverage.lcov
+
+      - name: Build documentation
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --no-deps
+
+      - name: Generate coverage report
+        run: genhtml -s  -t "Combined platforms" -o target/doc/coverage/ Linux-coverage.lcov macOS-coverage.lcov
+
+      - name: Patch documentation
+        run: |
+          CRATE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | cut -f2 -d"/")
+          echo "<meta http-equiv=\"refresh\" content=\"0; url=$CRATE_NAME/index.html\">" > target/doc/index.html
+          touch target/doc/.nojekyll
+
+      - name: Remove lockfile
+        run: rm target/doc/.lock
+
+      - name: Setup pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload documentation
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/doc
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.lcov
+          if-no-files-found: error
+
+  deploy-pages:
+    name: Deploy pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-24.04
+    needs: [pages]
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -198,9 +198,37 @@ jobs:
       - name: Check license header
         uses: apache/skywalking-eyes/header@main
 
+  dep-branches:
+    name: Constellation dependency branch check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Check branches for constellation dependencies
+        run: |
+          if `cargo tree | grep github.com/constellation-system | sed  's/[^?]*?//' | sed 's/#.*//' | sed 's/branch=//' | grep -Evq "^devel$"`; then
+            echo "Constellation depnedencies not on devel branch:"
+            cargo tree | grep github.com/constellation-system
+            exit 1
+          fi
+
   test-debug:
     name: Run tests with debug build
-    needs: [format, check, lint, audit, license]
+    needs: [format, check, lint, audit, license, dep-branches]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -289,7 +317,7 @@ jobs:
 
   test-release:
     name: Run tests with release build
-    needs: [format, check, lint, audit, license]
+    needs: [format, check, lint, audit, license, dep-branches]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -263,9 +263,6 @@ jobs:
           apt: libkrb5-dev llvm-${{ env.LLVM_VERSION }}
           brew: llvm@${{ env.LLVM_VERSION }}
 
-      - name: Generate test certificates
-        run: sh gen_test_certs.sh
-
       - name: Run tests
         if: matrix.os == 'ubuntu-24.04'
         uses: actions-rs/cargo@v1
@@ -293,7 +290,7 @@ jobs:
           for f in `find src -type f -regex ".*\.rs"`; do SRCS+="$f "; done
           TESTBINS=""
           CRATE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | cut -f2 -d"/")
-          for f in `find target/debug/deps -type f -regex "target/debug/deps/$CRATE_NAME\-[0-9a-f]*$"`; do TESTBINS+="$f "; done
+          for f in `find target/debug/deps -type f -regex "target/debug/deps/${CRATE_NAME//-/_}\-[0-9a-f]*$"`; do TESTBINS+="$f "; done
           llvm-cov-${{ env.LLVM_VERSION }} export --format=lcov --ignore-filename-regex="$HOME/.cargo/*|/rustc/" --instr-profile=target/coverage/coverage.profdata `echo $TESTBINS` `echo $SRCS` > target/coverage/${{ runner.os }}-coverage.lcov
 
       - name: Generate coverage report
@@ -305,7 +302,7 @@ jobs:
           for f in `find src -type f -regex ".*\.rs"`; do SRCS+="$f "; done
           TESTBINS=""
           CRATE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | cut -f2 -d"/")
-          for f in `find target/debug/deps -type f -regex "target/debug/deps/$CRATE_NAME\-[0-9a-f]*$"`; do TESTBINS+="$f "; done
+          for f in `find target/debug/deps -type f -regex "target/debug/deps/${CRATE_NAME//-/_}\-[0-9a-f]*$"`; do TESTBINS+="$f "; done
           /opt/homebrew/bin/llvm-cov export --format=lcov --ignore-filename-regex="$HOME/.cargo/*|/rustc/" --instr-profile=target/coverage/coverage.profdata `echo $TESTBINS` `echo $SRCS` > target/coverage/${{ runner.os }}-coverage.lcov
 
       - name: Upload coverage data
@@ -350,9 +347,6 @@ jobs:
         uses: ConorMacBride/install-package@v1
         with:
           apt: libkrb5-dev
-
-      - name: Generate test certificates
-        run: sh gen_test_certs.sh
 
       - name: Run tests
         if: matrix.os == 'ubuntu-24.04'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,423 @@
+name: Pull request builder
+
+run-name: Pull request for ${{ github.head_ref }} by ${{ github.actor }}
+
+env:
+  LINT_FLAGS: -W clippy::all -W clippy::pedantic -W clippy::cargo
+  RUST_TOOLCHAIN: 'nightly-2024-07-21'
+  LLVM_VERSION: 18
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - 'devel'
+
+permissions: {}
+
+jobs:
+  format:
+    name: Format check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+          components: rustfmt
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Check formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check --verbose
+
+  check:
+    name: Compile warnings
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Check for compile warnings
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  lint:
+    name: Lint check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+          components: clippy
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Lint check
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: -- ${{ env.LINT_PARAMS }}
+
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Install cargo-audit
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-audit --locked
+
+      - name: Audit code
+        uses: actions-rs/cargo@v1
+        with:
+          command: audit
+
+  license:
+    name: License header check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Check license header
+        uses: apache/skywalking-eyes/header@main
+
+  test-debug:
+    name: Run tests with debug build
+    needs: [format, check, lint, audit, license]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, macos-14]
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Install GSSAPI development and LLVM-${{ env.LLVM_VERSION }}
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev llvm-${{ env.LLVM_VERSION }}
+          brew: llvm@${{ env.LLVM_VERSION }}
+
+      - name: Generate test certificates
+        run: sh gen_test_certs.sh
+
+      - name: Run tests
+        if: matrix.os == 'ubuntu-24.04'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+        env:
+          RUSTFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Clink-dead-code'
+          LLVM_PROFILE_FILE: 'target/coverage/profile_%m_%p.profraw'
+
+      - name: Run tests
+        if: matrix.os == 'macos-14'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features log,openssl,unix
+        env:
+          RUSTFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Clink-dead-code --remap-path-prefix=${{ github.workspace }}='
+          LLVM_PROFILE_FILE: 'target/coverage/${{ runner.os }}_%m_%p.profraw'
+
+      - name: Generate coverage report
+        if: matrix.os == 'ubuntu-24.04'
+        run: |
+          llvm-profdata-${{ env.LLVM_VERSION }} merge --sparse target/coverage/*.profraw -o target/coverage/coverage.profdata
+          SRCS=""
+          for f in `find src -type f -regex ".*\.rs"`; do SRCS+="$f "; done
+          TESTBINS=""
+          CRATE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | cut -f2 -d"/")
+          for f in `find target/debug/deps -type f -regex "target/debug/deps/$CRATE_NAME\-[0-9a-f]*$"`; do TESTBINS+="$f "; done
+          llvm-cov-${{ env.LLVM_VERSION }} export --format=lcov --ignore-filename-regex="$HOME/.cargo/*|/rustc/" --instr-profile=target/coverage/coverage.profdata `echo $TESTBINS` `echo $SRCS` > target/coverage/${{ runner.os }}-coverage.lcov
+
+      - name: Generate coverage report
+        if: matrix.os == 'macos-14'
+        run: |
+          /opt/homebrew/bin/brew link llvm@18
+          /opt/homebrew/bin/llvm-profdata merge --sparse target/coverage/*.profraw -o target/coverage/coverage.profdata
+          SRCS=""
+          for f in `find src -type f -regex ".*\.rs"`; do SRCS+="$f "; done
+          TESTBINS=""
+          CRATE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]' | cut -f2 -d"/")
+          for f in `find target/debug/deps -type f -regex "target/debug/deps/$CRATE_NAME\-[0-9a-f]*$"`; do TESTBINS+="$f "; done
+          /opt/homebrew/bin/llvm-cov export --format=lcov --ignore-filename-regex="$HOME/.cargo/*|/rustc/" --instr-profile=target/coverage/coverage.profdata `echo $TESTBINS` `echo $SRCS` > target/coverage/${{ runner.os }}-coverage.lcov
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}
+          path: target/coverage/${{ runner.os }}-coverage.lcov
+          if-no-files-found: error
+
+  test-release:
+    name: Run tests with release build
+    needs: [format, check, lint, audit, license]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, macos-14]
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Generate test certificates
+        run: sh gen_test_certs.sh
+
+      - name: Run tests
+        if: matrix.os == 'ubuntu-24.04'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release
+
+      - name: Run tests
+        if: matrix.os == 'macos-14'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --no-default-features --features log,openssl,unix
+
+  coverage-report:
+    name: Generate coverage report
+    needs: [test-debug]
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Install lcov
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: lcov
+
+      - name: Download ubuntu-24.04 coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-ubuntu-24.04
+
+      - name: Download macos-14 coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-macos-14
+
+      - name: Merge lcov files
+        run: lcov -a Linux-coverage.lcov -t linux -a macOS-coverage.lcov -t macos -o coverage.lcov
+
+      - name: Publish coverage report
+        uses: romeovs/lcov-reporter-action@v0.3.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          lcov-file: coverage.lcov
+
+  doc:
+    name: Generate rustdoc
+    needs: [test-debug, test-release]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Build documentation
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --no-deps
+
+      - name: Patch documentation
+        run: |
+          CRATE_NAME=$(echo '${{ github.repository }}' | tr `[:upper:]` '[:lower:]' | cut -f2 -d"/")
+          echo "<meta http-equiv=\"refresh\" content=\"0; url=${CRATE_NAME/-/_}\">" > target/doc/index.html
+          touch target/doc/.nojekyll
+
+      - name: Upload documentation
+        uses: actions/upload-artifact@v4
+        with:
+          name: rustdoc
+          path: target/doc

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,43 @@
+header:
+  license:
+    spdx-id: AGPL-3.0-only
+    copyright-owner: The Johns Hopkins Applied Physics Laboratory LLC
+    copyright-year: 2024
+    software-name: Constellation
+    content: | #
+      Copyright © 2024 The Johns Hopkins Applied Physics Laboratory LLC.
+
+      This program is free software: you can redistribute it and/or modify
+      it under the terms of the GNU Affero General Public License, version
+      3, as published by the Free Software Foundation.  If you
+      would like to purchase a commercial license for this software, please
+      contact APL’s Tech Transfer at 240-592-0817 or
+      techtransfer@jhuapl.edu.
+
+      This program is distributed in the hope that it will be useful, but
+      WITHOUT ANY WARRANTY; without even the implied warranty of
+      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+      Affero General Public License for more details.
+
+      You should have received a copy of the GNU Affero General Public
+      License along with this program.  If not, see
+      <https://www.gnu.org/licenses/>.
+
+  paths-ignore:
+    - '.github/**'
+    - 'target/**'
+    - 'test/data/certs/*'
+    - 'gen_test_certs.sh'
+    - 'build.rs'
+    - '**/*.asn1'
+    - '*.md'
+    - '.gitignore'
+    - '.licenserc.yaml'
+    - 'rustfmt.toml'
+    - 'LICENSE'
+
+  comment: on-failure
+
+dependency:
+  files:
+    - Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ unix = [
 [dependencies]
 asn1rs = { version = "0.3" }
 bitvec = { version = "1.0" }
-constellation-common = { git = "https://github.com/constellation-system/constellation-common.git", branch = "import", default-features = false }
-constellation-consensus-common = { git = "https://github.com/constellation-system/constellation-consensus-common.git", branch = "import", default-features = false }
+constellation-common = { git = "https://github.com/constellation-system/constellation-common.git", branch = "devel", default-features = false }
+constellation-consensus-common = { git = "https://github.com/constellation-system/constellation-consensus-common.git", branch = "devel", default-features = false }
 log = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,40 @@ exclude = [
     ".gitignore"
 ]
 edition = "2018"
+
+[features]
+default = ["gssapi", "log", "openssl", "unix"]
+gssapi = [
+    "constellation-common/gssapi",
+    "constellation-consensus-common/gssapi"
+]
+log = [
+    "dep:log",
+    "constellation-common/log",
+    "constellation-consensus-common/log"
+]
+openssl = [
+    "constellation-common/openssl",
+    "constellation-consensus-common/openssl"
+]
+unix = [
+    "constellation-common/unix",
+    "constellation-consensus-common/unix"
+]
+
+[dependencies]
+asn1rs = { version = "0.2" }
+bitvec = { version = "1.0" }
+constellation-common = { git = "https://github.com/constellation-system/constellation-common.git", branch = "import", default-features = false }
+constellation-consensus-common = { git = "https://github.com/constellation-system/constellation-consensus-common.git", branch = "import", default-features = false }
+log = { version = "0.4", optional = true }
+serde = { version = "1.0", features = ["derive"] }
+
+rand = { version = "0.8" }
+
+[build-dependencies]
+asn1rs = { version = "0.2" }
+
+[dev-dependencies]
+env_logger = { version = "0.10" }
+serde_yaml = { version = "0.9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@
 [package]
 name = "constellation-pbft"
 description = "Castro-Liskov PBFT consensus protocol implementation for the Constellation distributed systems platform"
+repository = "https://github.com/constellation-system/constellation-pbft"
 version = "0.0.0"
 authors = [ "Eric McCorkle <eric.mccorkle@jhuapl.edu>" ]
 rust-version = "1.81"
@@ -51,7 +52,7 @@ unix = [
 ]
 
 [dependencies]
-asn1rs = { version = "0.2" }
+asn1rs = { version = "0.3" }
 bitvec = { version = "1.0" }
 constellation-common = { git = "https://github.com/constellation-system/constellation-common.git", branch = "import", default-features = false }
 constellation-consensus-common = { git = "https://github.com/constellation-system/constellation-consensus-common.git", branch = "import", default-features = false }
@@ -61,7 +62,7 @@ serde = { version = "1.0", features = ["derive"] }
 rand = { version = "0.8" }
 
 [build-dependencies]
-asn1rs = { version = "0.2" }
+asn1rs = { version = "0.3" }
 
 [dev-dependencies]
 env_logger = { version = "0.10" }

--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 **Constellation is under active development and has not undergone
 rigorous security evaluation.  It cannot offer strong security
 guarantees at present.**
+
+## Quicklinks
+
+* [Developer documentation for `devel` branch](https://constellation-system.github.io/constellation-pbft/index.html)
+* [Coverage reports for `devel` branch](https://constellation-system.github.io/constellation-pbft/coverage/index.html)

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,54 @@
+use std::io::Result;
+use std::path::Path;
+
+use asn1rs::converter::Converter;
+use asn1rs::gen::rust::RustCodeGenerator;
+
+fn load_files(
+    dir: &Path,
+    converter: &mut Converter
+) -> Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path.is_dir() {
+            load_files(&path, converter)?;
+        } else {
+            match path.as_os_str().to_os_string().into_string() {
+                Ok(path) if path.ends_with(".asn1") => {
+                    println!("cargo:rerun-if-changed={}", &path);
+
+                    if let Err(e) = converter.load_file(&path) {
+                        panic!("Couldn't load {}: {:?}", &path, e);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn main() {
+    let mut converter = Converter::default();
+
+    load_files(Path::new("./src/asn1"), &mut converter)
+        .expect("Error loading ASN.1 files");
+
+    let generated = Path::new("src/generated");
+
+    if !generated.is_dir() {
+        std::fs::create_dir(generated).expect("Could not create directory");
+    }
+
+    if let Err(e) =
+        converter.to_rust(generated, |gen: &mut RustCodeGenerator| {
+            gen.add_global_derive("serde::Deserialize");
+            gen.add_global_derive("serde::Serialize");
+        })
+    {
+        panic!("Error generating rust: {:?}", e);
+    }
+}

--- a/src/asn1/msgs.asn1
+++ b/src/asn1/msgs.asn1
@@ -1,0 +1,36 @@
+Msgs DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+IMPORTS PBFTRequest FROM Req;
+
+PBFTAckState ::= ENUMERATED {
+    Prepare (0),
+    Commit (1),
+    Complete (2),
+    Fail (3)
+}
+
+PBFTStateUpdate ::= CHOICE {
+    Prepare PBFTRequest,
+    Commit PBFTRequest,
+    Complete PBFTRequest,
+    Fail NULL
+}
+
+PBFTUpdateAck ::= SEQUENCE {
+    update PBFTStateUpdate,
+    ack PBFTAckState
+}
+
+PBFTContent ::= CHOICE {
+    UpdateAck PBFTUpdateAck,
+    Update PBFTStateUpdate,
+    Ack PBFTAckState
+}
+
+PBFTMsg ::= SEQUENCE {
+    round OCTET STRING (SIZE (16)),
+    content PBFTContent
+}
+
+END

--- a/src/asn1/req.asn1
+++ b/src/asn1/req.asn1
@@ -1,0 +1,24 @@
+Req DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+PBFTView ::= SEQUENCE {
+    id OCTET STRING SIZE (64)
+}
+
+PBFTAction ::= ENUMERATED {
+    Evict (0),
+    Admit (1)
+}
+
+PBFTMember ::= SEQUENCE {
+    action PBFTAction,
+    id OCTET STRING SIZE (64)
+}
+
+PBFTRequest ::= CHOICE {
+    Payload OCTET STRING SIZE (1..1024),
+    Members SEQUENCE SIZE (1..16) OF PBFTMember,
+    View PBFTView
+}
+
+END

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,135 @@
+// Copyright © 2024 The Johns Hopkins Applied Physics Laboratory LLC.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU Affero General Public License,
+// version 3, as published by the Free Software Foundation.  If you
+// would like to purchase a commercial license for this software, please
+// contact APL’s Tech Transfer at 240-592-0817 or
+// techtransfer@jhuapl.edu.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+//! Configuration objects.
+use constellation_common::hashid::CompoundHashAlgo;
+use constellation_common::retry::Retry;
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Configuration for a PBFT protocol instance.
+#[derive(
+    Clone, Debug, Default, Deserialize, PartialEq, PartialOrd, Serialize,
+)]
+#[serde(rename = "pbft-config")]
+#[serde(rename_all = "kebab-case")]
+#[serde(default)]
+pub struct PBFTConfig {
+    // Maximum number of concurrent rounds that
+    // can execute at once.
+    // max_concurrent_rounds: usize,
+    // Number of rounds before we start
+    // proposing view changes.
+    // view_change_rounds: usize,
+    // Wall-clock time before we start proposing
+    // view changes.
+    // view_change_time: Option<Duration>
+    #[serde(flatten)]
+    state: PBFTProtoStateConfig
+}
+
+/// Configuration for individual rounds for the PBFT consensus protocol.
+#[derive(
+    Clone, Debug, Default, Deserialize, PartialEq, PartialOrd, Serialize,
+)]
+#[serde(rename = "pbft-state-config")]
+#[serde(rename_all = "kebab-case")]
+#[serde(default)]
+pub struct PBFTProtoStateConfig {
+    /// Name of the hash function used on parties.
+    #[serde(default)]
+    party_hash: CompoundHashAlgo,
+    /// Outbound buffer configurations.
+    #[serde(default)]
+    #[serde(flatten)]
+    outbound: PBFTOutboundConfig
+}
+
+/// Configuration for the PBFT outbound message buffer.
+#[derive(
+    Clone, Debug, Default, Deserialize, PartialEq, PartialOrd, Serialize,
+)]
+#[serde(rename = "pbft-config")]
+#[serde(rename_all = "kebab-case")]
+#[serde(default)]
+pub struct PBFTOutboundConfig {
+    #[serde(default)]
+    retry: Retry
+}
+
+impl PBFTProtoStateConfig {
+    #[inline]
+    pub fn create(
+        party_hash: CompoundHashAlgo,
+        outbound: PBFTOutboundConfig
+    ) -> Self {
+        PBFTProtoStateConfig {
+            party_hash: party_hash,
+            outbound: outbound
+        }
+    }
+
+    #[inline]
+    pub fn party_hash(&self) -> &CompoundHashAlgo {
+        &self.party_hash
+    }
+
+    #[inline]
+    pub fn outbound(&self) -> &PBFTOutboundConfig {
+        &self.outbound
+    }
+
+    #[inline]
+    pub fn take(self) -> (CompoundHashAlgo, PBFTOutboundConfig) {
+        (self.party_hash, self.outbound)
+    }
+}
+
+impl PBFTConfig {
+    #[inline]
+    pub fn create(state: PBFTProtoStateConfig) -> Self {
+        PBFTConfig { state: state }
+    }
+
+    #[inline]
+    pub fn state(&self) -> &PBFTProtoStateConfig {
+        &self.state
+    }
+
+    #[inline]
+    pub fn take(self) -> PBFTProtoStateConfig {
+        self.state
+    }
+}
+
+impl PBFTOutboundConfig {
+    #[inline]
+    pub fn create(retry: Retry) -> Self {
+        PBFTOutboundConfig { retry: retry }
+    }
+
+    #[inline]
+    pub fn retry(&self) -> &Retry {
+        &self.retry
+    }
+
+    #[inline]
+    pub fn take(self) -> Retry {
+        self.retry
+    }
+}

--- a/src/generated/mod.rs
+++ b/src/generated/mod.rs
@@ -1,0 +1,20 @@
+// Copyright © 2024 The Johns Hopkins Applied Physics Laboratory LLC.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU Affero General Public License,
+// version 3, as published by the Free Software Foundation.  If you
+// would like to purchase a commercial license for this software, please
+// contact APL’s Tech Transfer at 240-592-0817 or
+// techtransfer@jhuapl.edu.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+pub mod msgs;
+pub mod req;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,60 @@
+// Copyright © 2024 The Johns Hopkins Applied Physics Laboratory LLC.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU Affero General Public License,
+// version 3, as published by the Free Software Foundation.  If you
+// would like to purchase a commercial license for this software, please
+// contact APL’s Tech Transfer at 240-592-0817 or
+// techtransfer@jhuapl.edu.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+//! Implementation of the Castro-Liskov PBFT consensus protocol.
+//!
+//! This crate provides an implementation of the Castro-Liskov PBFT
+//! consensus protocol usable in the Constellation distributed systems
+//! platfrom.  The Castro-Liskov protocol is described by the paper
+//! [Practical Byzantine Fault
+//! Tolerance](https://dl.acm.org/doi/10.5555/296806.296824).  It
+//! provide a consensus protocol resilient against a Byzantine
+//! Adversary who controls up to but not including 1/3rd of the
+//! parties in the consensus pool.
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+#![allow(clippy::redundant_field_names)]
+
+pub mod config;
+pub mod msgs;
+pub mod proto;
+pub mod state;
+
+#[allow(clippy::all)]
+#[rustfmt::skip]
+mod generated;
+mod outbound;
+
+#[cfg(test)]
+use std::sync::Once;
+
+#[cfg(test)]
+use log::LevelFilter;
+
+#[cfg(test)]
+static INIT: Once = Once::new();
+
+#[cfg(test)]
+fn init() {
+    INIT.call_once(|| {
+        env_logger::builder()
+            .is_test(true)
+            .filter_level(LevelFilter::Trace)
+            .init()
+    })
+}

--- a/src/msgs.rs
+++ b/src/msgs.rs
@@ -1,0 +1,2322 @@
+// Copyright © 2024 The Johns Hopkins Applied Physics Laboratory LLC.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU Affero General Public License,
+// version 3, as published by the Free Software Foundation.  If you
+// would like to purchase a commercial license for this software, please
+// contact APL’s Tech Transfer at 240-592-0817 or
+// techtransfer@jhuapl.edu.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+//! Protocol messages.
+use std::fmt::Display;
+use std::fmt::Error;
+use std::fmt::Formatter;
+
+use constellation_common::codec::per::PERCodec;
+use constellation_common::hashid::HashID;
+use constellation_consensus_common::round::RoundMsg;
+
+pub use crate::generated::msgs::PbftContent;
+pub use crate::generated::msgs::PbftMsg;
+pub use crate::generated::req::PbftAction;
+pub use crate::generated::req::PbftMember;
+pub use crate::generated::req::PbftRequest;
+pub use crate::generated::req::PbftView;
+
+impl Eq for PbftContent {}
+impl Eq for PbftMsg {}
+impl Eq for PbftRequest {}
+
+pub type PBFTMsgPERCodec = PERCodec<PbftMsg, 8348>;
+
+impl<RoundID> RoundMsg<RoundID> for PbftMsg
+where
+    RoundID: Clone + Display + Ord + From<u128> + Into<u128>
+{
+    type Payload = PbftContent;
+
+    #[inline]
+    fn create(
+        round: RoundID,
+        payload: Self::Payload
+    ) -> Self {
+        let round: u128 = round.into();
+        let round = vec![
+            (round >> 120) as u8,
+            (round >> 112) as u8,
+            (round >> 104) as u8,
+            (round >> 96) as u8,
+            (round >> 88) as u8,
+            (round >> 80) as u8,
+            (round >> 72) as u8,
+            (round >> 64) as u8,
+            (round >> 56) as u8,
+            (round >> 48) as u8,
+            (round >> 40) as u8,
+            (round >> 32) as u8,
+            (round >> 24) as u8,
+            (round >> 16) as u8,
+            (round >> 8) as u8,
+            round as u8,
+        ];
+
+        PbftMsg {
+            round: round,
+            content: payload
+        }
+    }
+
+    #[inline]
+    fn round_id(&self) -> RoundID {
+        let mut out = self.round[15] as u128;
+
+        out |= (self.round[14] as u128) << 8;
+        out |= (self.round[13] as u128) << 16;
+        out |= (self.round[12] as u128) << 24;
+        out |= (self.round[11] as u128) << 32;
+        out |= (self.round[10] as u128) << 40;
+        out |= (self.round[9] as u128) << 48;
+        out |= (self.round[8] as u128) << 56;
+        out |= (self.round[7] as u128) << 64;
+        out |= (self.round[6] as u128) << 72;
+        out |= (self.round[5] as u128) << 80;
+        out |= (self.round[4] as u128) << 88;
+        out |= (self.round[3] as u128) << 96;
+        out |= (self.round[2] as u128) << 104;
+        out |= (self.round[1] as u128) << 112;
+        out |= (self.round[0] as u128) << 120;
+
+        out.into()
+    }
+
+    #[inline]
+    fn payload(&self) -> &Self::Payload {
+        &self.content
+    }
+
+    #[inline]
+    fn take(self) -> (RoundID, Self::Payload) {
+        (self.round_id(), self.content)
+    }
+}
+
+impl Display for PbftAction {
+    fn fmt(
+        &self,
+        f: &mut Formatter<'_>
+    ) -> Result<(), Error> {
+        match self {
+            PbftAction::Admit => write!(f, "admit"),
+            PbftAction::Evict => write!(f, "evict")
+        }
+    }
+}
+
+impl Display for PbftMember {
+    fn fmt(
+        &self,
+        f: &mut Formatter<'_>
+    ) -> Result<(), Error> {
+        write!(f, "{} ", self.action)?;
+
+        for byte in self.id.iter() {
+            write!(f, "{:02x}", byte)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl PbftRequest {
+    #[inline]
+    pub fn view_change<ID>(id: &ID) -> Self
+    where
+        ID: HashID {
+        PbftRequest::View(PbftView {
+            id: id.bytes().to_vec()
+        })
+    }
+}
+
+impl Display for PbftRequest {
+    fn fmt(
+        &self,
+        f: &mut Formatter<'_>
+    ) -> Result<(), Error> {
+        match self {
+            PbftRequest::Payload(bytes) => {
+                write!(f, "payload: ")?;
+
+                for byte in bytes {
+                    write!(f, "{:02x}", byte)?;
+                }
+
+                Ok(())
+            }
+            PbftRequest::Members(members) => {
+                let mut first = true;
+
+                write!(f, "member update:")?;
+
+                for member in members {
+                    if first {
+                        first = false;
+
+                        write!(f, " {}", member)?;
+                    } else {
+                        write!(f, ", {}", member)?;
+                    }
+                }
+
+                Ok(())
+            }
+            PbftRequest::View(PbftView { id }) => {
+                write!(f, "view change, new leader: ")?;
+
+                for byte in id {
+                    write!(f, "{:02x}", byte)?;
+                }
+
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+use asn1rs::prelude::Null;
+#[cfg(test)]
+use asn1rs::prelude::Reader;
+#[cfg(test)]
+use asn1rs::prelude::Writer;
+#[cfg(test)]
+use asn1rs::syn::io::UperReader;
+#[cfg(test)]
+use asn1rs::syn::io::UperWriter;
+#[cfg(test)]
+use constellation_common::codec::DatagramCodec;
+
+#[cfg(test)]
+use crate::generated::msgs::PbftAckState;
+#[cfg(test)]
+use crate::generated::msgs::PbftStateUpdate;
+#[cfg(test)]
+use crate::generated::msgs::PbftUpdateAck;
+
+#[cfg(test)]
+const UDP_MTU: usize = 1472;
+
+#[cfg(test)]
+fn make_payload_request() -> PbftRequest {
+    let mut payload = vec![0; 1024];
+
+    for i in 0..1024 {
+        payload[i] = i as u8 / 4;
+    }
+
+    PbftRequest::Payload(payload)
+}
+
+#[cfg(test)]
+fn make_members_request() -> PbftRequest {
+    let mut members = Vec::with_capacity(16);
+
+    for i in 0..16 {
+        let id = vec![i as u8; 64];
+        let action = if i % 2 == 1 {
+            PbftAction::Admit
+        } else {
+            PbftAction::Evict
+        };
+
+        members.push(PbftMember {
+            id: id,
+            action: action
+        })
+    }
+
+    PbftRequest::Members(members)
+}
+
+#[test]
+fn test_request_payload() {
+    let req = make_payload_request();
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftRequest>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_request_members() {
+    let req = make_members_request();
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftRequest>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_request_view() {
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftRequest>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_prepare_payload() {
+    let req =
+        PbftContent::Update(PbftStateUpdate::Prepare(make_payload_request()));
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_prepare_members() {
+    let req =
+        PbftContent::Update(PbftStateUpdate::Prepare(make_members_request()));
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_prepare_view() {
+    let req = PbftContent::Update(PbftStateUpdate::Prepare(PbftRequest::View(
+        PbftView { id: vec![0; 64] }
+    )));
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_commit_payload() {
+    let req =
+        PbftContent::Update(PbftStateUpdate::Commit(make_payload_request()));
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_commit_members() {
+    let req =
+        PbftContent::Update(PbftStateUpdate::Commit(make_members_request()));
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_commit_view() {
+    let req = PbftContent::Update(PbftStateUpdate::Commit(PbftRequest::View(
+        PbftView { id: vec![0; 64] }
+    )));
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_complete_payload() {
+    let req =
+        PbftContent::Update(PbftStateUpdate::Complete(make_payload_request()));
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_complete_members() {
+    let req =
+        PbftContent::Update(PbftStateUpdate::Complete(make_members_request()));
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_complete_view() {
+    let req = PbftContent::Update(PbftStateUpdate::Complete(
+        PbftRequest::View(PbftView { id: vec![0; 64] })
+    ));
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_fail() {
+    let req = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_ack_prepare() {
+    let req = PbftContent::Ack(PbftAckState::Prepare);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_ack_commit() {
+    let req = PbftContent::Ack(PbftAckState::Commit);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_ack_complete() {
+    let req = PbftContent::Ack(PbftAckState::Complete);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_ack_fail() {
+    let req = PbftContent::Ack(PbftAckState::Fail);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_prepare_payload_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(make_payload_request()),
+        ack: PbftAckState::Prepare
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_prepare_payload_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(make_payload_request()),
+        ack: PbftAckState::Commit
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_prepare_payload_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(make_payload_request()),
+        ack: PbftAckState::Complete
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_prepare_payload_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(make_payload_request()),
+        ack: PbftAckState::Fail
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_prepare_members_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(make_members_request()),
+        ack: PbftAckState::Prepare
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_prepare_members_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(make_members_request()),
+        ack: PbftAckState::Commit
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_prepare_members_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(make_members_request()),
+        ack: PbftAckState::Complete
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_prepare_members_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(make_members_request()),
+        ack: PbftAckState::Fail
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_prepare_view_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Prepare
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_prepare_view_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Commit
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_prepare_view_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Complete
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_prepare_view_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Fail
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_commit_payload_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(make_payload_request()),
+        ack: PbftAckState::Prepare
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_commit_payload_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(make_payload_request()),
+        ack: PbftAckState::Commit
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_commit_payload_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(make_payload_request()),
+        ack: PbftAckState::Complete
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_commit_payload_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(make_payload_request()),
+        ack: PbftAckState::Fail
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_commit_members_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(make_members_request()),
+        ack: PbftAckState::Prepare
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_commit_members_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(make_members_request()),
+        ack: PbftAckState::Commit
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_commit_members_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(make_members_request()),
+        ack: PbftAckState::Complete
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_commit_members_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(make_members_request()),
+        ack: PbftAckState::Fail
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_commit_view_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Prepare
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_commit_view_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Commit
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_commit_view_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Complete
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_commit_view_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Fail
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_complete_payload_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(make_payload_request()),
+        ack: PbftAckState::Prepare
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_complete_payload_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(make_payload_request()),
+        ack: PbftAckState::Commit
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_complete_payload_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(make_payload_request()),
+        ack: PbftAckState::Complete
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_complete_payload_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(make_payload_request()),
+        ack: PbftAckState::Fail
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_complete_members_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(make_members_request()),
+        ack: PbftAckState::Prepare
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_complete_members_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(make_members_request()),
+        ack: PbftAckState::Commit
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_complete_members_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(make_members_request()),
+        ack: PbftAckState::Complete
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_complete_members_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(make_members_request()),
+        ack: PbftAckState::Fail
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_complete_view_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Prepare
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_complete_view_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Commit
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_complete_view_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Complete
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_complete_view_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Fail
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_fail_view_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Fail(Null),
+        ack: PbftAckState::Prepare
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_fail_view_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Fail(Null),
+        ack: PbftAckState::Commit
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_fail_view_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Fail(Null),
+        ack: PbftAckState::Complete
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_update_fail_view_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Fail(Null),
+        ack: PbftAckState::Fail
+    };
+    let req = PbftContent::UpdateAck(update_ack);
+    let mut writer = UperWriter::default();
+
+    writer.write(&req).expect("Expected success");
+
+    let nbits = writer.bit_len();
+    let bytes = writer.into_bytes_vec();
+
+    assert!(bytes.len() <= UDP_MTU);
+
+    let mut reader = UperReader::from((&bytes[..], nbits));
+    let result = reader.read::<PbftContent>().unwrap();
+
+    assert_eq!(req, result);
+}
+
+#[test]
+fn test_msg_codec_update_prepare_payload() {
+    let msg = PbftMsg::create(
+        0xff00,
+        PbftContent::Update(PbftStateUpdate::Prepare(make_payload_request()))
+    );
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_prepare_members() {
+    let msg = PbftMsg::create(
+        0xff00,
+        PbftContent::Update(PbftStateUpdate::Prepare(make_members_request()))
+    );
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_prepare_view() {
+    let msg = PbftMsg::create(
+        0xff00,
+        PbftContent::Update(PbftStateUpdate::Prepare(PbftRequest::View(
+            PbftView { id: vec![0; 64] }
+        )))
+    );
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_commit_payload() {
+    let msg = PbftMsg::create(
+        0xff00,
+        PbftContent::Update(PbftStateUpdate::Commit(make_payload_request()))
+    );
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_commit_members() {
+    let msg = PbftMsg::create(
+        0xff00,
+        PbftContent::Update(PbftStateUpdate::Commit(make_members_request()))
+    );
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_commit_view() {
+    let msg = PbftMsg::create(
+        0xff00,
+        PbftContent::Update(PbftStateUpdate::Commit(PbftRequest::View(
+            PbftView { id: vec![0; 64] }
+        )))
+    );
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_complete_payload() {
+    let msg = PbftMsg::create(
+        0xff00,
+        PbftContent::Update(PbftStateUpdate::Complete(make_payload_request()))
+    );
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_complete_members() {
+    let msg = PbftMsg::create(
+        0xff00,
+        PbftContent::Update(PbftStateUpdate::Complete(make_members_request()))
+    );
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_complete_view() {
+    let msg = PbftMsg::create(
+        0xff00,
+        PbftContent::Update(PbftStateUpdate::Complete(PbftRequest::View(
+            PbftView { id: vec![0; 64] }
+        )))
+    );
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_fail() {
+    let msg = PbftMsg::create(
+        0xff00,
+        PbftContent::Update(PbftStateUpdate::Fail(Null))
+    );
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_ack_prepare() {
+    let msg = PbftMsg::create(0xff00, PbftContent::Ack(PbftAckState::Prepare));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_ack_commit() {
+    let msg = PbftMsg::create(0xff00, PbftContent::Ack(PbftAckState::Commit));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_ack_complete() {
+    let msg = PbftMsg::create(0xff00, PbftContent::Ack(PbftAckState::Complete));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_ack_fail() {
+    let msg = PbftMsg::create(0xff00, PbftContent::Ack(PbftAckState::Fail));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_prepare_payload_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(make_payload_request()),
+        ack: PbftAckState::Prepare
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_prepare_payload_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(make_payload_request()),
+        ack: PbftAckState::Commit
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_prepare_payload_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(make_payload_request()),
+        ack: PbftAckState::Complete
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_prepare_payload_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(make_payload_request()),
+        ack: PbftAckState::Fail
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_prepare_members_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(make_members_request()),
+        ack: PbftAckState::Prepare
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_prepare_members_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(make_members_request()),
+        ack: PbftAckState::Commit
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_prepare_members_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(make_members_request()),
+        ack: PbftAckState::Complete
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_prepare_members_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(make_members_request()),
+        ack: PbftAckState::Fail
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_prepare_view_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Prepare
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_prepare_view_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Commit
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_prepare_view_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Complete
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_prepare_view_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Prepare(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Fail
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_commit_payload_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(make_payload_request()),
+        ack: PbftAckState::Prepare
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_commit_payload_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(make_payload_request()),
+        ack: PbftAckState::Commit
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_commit_payload_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(make_payload_request()),
+        ack: PbftAckState::Complete
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_commit_payload_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(make_payload_request()),
+        ack: PbftAckState::Fail
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_commit_members_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(make_members_request()),
+        ack: PbftAckState::Prepare
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_commit_members_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(make_members_request()),
+        ack: PbftAckState::Commit
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_commit_members_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(make_members_request()),
+        ack: PbftAckState::Complete
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_commit_members_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(make_members_request()),
+        ack: PbftAckState::Fail
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_commit_view_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Prepare
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_commit_view_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Commit
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_commit_view_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Complete
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_commit_view_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Commit(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Fail
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_complete_payload_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(make_payload_request()),
+        ack: PbftAckState::Prepare
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_complete_payload_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(make_payload_request()),
+        ack: PbftAckState::Commit
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_complete_payload_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(make_payload_request()),
+        ack: PbftAckState::Fail
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_complete_members_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(make_members_request()),
+        ack: PbftAckState::Prepare
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_complete_members_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(make_members_request()),
+        ack: PbftAckState::Commit
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_complete_members_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(make_members_request()),
+        ack: PbftAckState::Complete
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_complete_members_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(make_members_request()),
+        ack: PbftAckState::Fail
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_complete_view_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Prepare
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_complete_view_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Commit
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_complete_view_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Complete
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_complete_view_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Complete(PbftRequest::View(PbftView {
+            id: vec![0; 64]
+        })),
+        ack: PbftAckState::Fail
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_fail_view_ack_prepare() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Fail(Null),
+        ack: PbftAckState::Prepare
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_fail_view_ack_commit() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Fail(Null),
+        ack: PbftAckState::Commit
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_fail_view_ack_complete() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Fail(Null),
+        ack: PbftAckState::Complete
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}
+
+#[test]
+fn test_msg_codec_update_fail_view_ack_fail() {
+    let update_ack = PbftUpdateAck {
+        update: PbftStateUpdate::Fail(Null),
+        ack: PbftAckState::Fail
+    };
+    let msg = PbftMsg::create(0xff00, PbftContent::UpdateAck(update_ack));
+    let mut codec = PBFTMsgPERCodec::create(()).unwrap();
+    let mut buf = [0; PBFTMsgPERCodec::MAX_BYTES];
+    let nencoded = codec.encode(&msg, &mut buf[..]).unwrap();
+    let (actual, nbytes) = codec.decode(&buf[..]).unwrap();
+
+    assert_eq!(msg, actual);
+    assert_eq!(nencoded, nbytes);
+}

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -18,14 +18,12 @@
 
 //! Outbound message buffer for the Castro-Liskov PBFT protocol.
 use std::collections::hash_map::Entry;
-use std::collections::hash_map::IntoIter;
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::fmt::Display;
 use std::fmt::Error;
 use std::fmt::Formatter;
 use std::hash::Hash;
-use std::iter::FusedIterator;
 use std::marker::PhantomData;
 use std::time::Instant;
 
@@ -125,11 +123,6 @@ pub struct PBFTOutbound<RoundID> {
     acks: BitVec
 }
 
-/// Iterator for [PBFTOutbound].
-pub struct PBFTOutboundIter {
-    inner: IntoIter<PbftMsg, BitVec>
-}
-
 impl From<usize> for OutboundPartyIdx {
     #[inline]
     fn from(val: usize) -> Self {
@@ -141,46 +134,6 @@ impl From<OutboundPartyIdx> for usize {
     #[inline]
     fn from(val: OutboundPartyIdx) -> usize {
         val.0
-    }
-}
-
-impl Iterator for PBFTOutboundIter {
-    type Item = OutboundGroup<PbftMsg>;
-
-    #[inline]
-    fn nth(
-        &mut self,
-        n: usize
-    ) -> Option<OutboundGroup<PbftMsg>> {
-        self.inner
-            .nth(n)
-            .map(|(msg, bitvec)| OutboundGroup::create(bitvec, msg))
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
-    }
-
-    #[inline]
-    fn next(&mut self) -> Option<OutboundGroup<PbftMsg>> {
-        self.inner
-            .next()
-            .map(|(msg, bitvec)| OutboundGroup::create(bitvec, msg))
-    }
-
-    #[inline]
-    fn count(self) -> usize {
-        self.inner.count()
-    }
-}
-
-impl FusedIterator for PBFTOutboundIter {}
-
-impl ExactSizeIterator for PBFTOutboundIter {
-    #[inline]
-    fn len(&self) -> usize {
-        self.inner.len()
     }
 }
 

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -1,0 +1,6323 @@
+// Copyright © 2024 The Johns Hopkins Applied Physics Laboratory LLC.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU Affero General Public License,
+// version 3, as published by the Free Software Foundation.  If you
+// would like to purchase a commercial license for this software, please
+// contact APL’s Tech Transfer at 240-592-0817 or
+// techtransfer@jhuapl.edu.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+//! Outbound message buffer for the Castro-Liskov PBFT protocol.
+use std::collections::hash_map::Entry;
+use std::collections::hash_map::IntoIter;
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::fmt::Display;
+use std::fmt::Error;
+use std::fmt::Formatter;
+use std::hash::Hash;
+use std::iter::FusedIterator;
+use std::marker::PhantomData;
+use std::time::Instant;
+
+use asn1rs::prelude::Null;
+use bitvec::bitvec;
+use bitvec::vec::BitVec;
+use constellation_common::retry::Retry;
+use constellation_consensus_common::outbound::Outbound;
+use constellation_consensus_common::outbound::OutboundGroup;
+use constellation_consensus_common::round::RoundMsg;
+use log::debug;
+use log::error;
+use log::trace;
+use log::warn;
+
+use crate::config::PBFTOutboundConfig;
+use crate::generated::msgs::PbftAckState;
+use crate::generated::msgs::PbftContent;
+use crate::generated::msgs::PbftMsg;
+use crate::generated::msgs::PbftStateUpdate;
+use crate::generated::msgs::PbftUpdateAck;
+use crate::generated::req::PbftRequest;
+
+/// Outbound message interface for the PBFT protocol.
+pub(crate) trait PBFTOutboundSend<Req> {
+    // Request to send a prepare message to all parties.
+    fn send_prepare(
+        &mut self,
+        req: &Req
+    );
+
+    // Request to send a commit message to all parties.
+    fn send_commit(
+        &mut self,
+        req: &Req
+    );
+
+    // Request to send complete messages from here on.
+    fn send_complete(
+        &mut self,
+        req: &Req
+    );
+
+    // Request to send a failure message to all parties.
+    fn send_fail(&mut self);
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct OutboundPartyIdx(usize);
+
+#[derive(Copy, Clone, Debug)]
+enum PartyPhase {
+    /// Starting phase, all messages matter.
+    Prepare,
+    /// Commit phase; prepare messages are now redundant.
+    Commit,
+    /// Resolution phase; commit and prepare messages are now redundant.
+    Resolved,
+    /// Party has acknowledged our resolution message.
+    Acknowledged
+}
+
+#[derive(Clone, Debug)]
+enum LocalPhase {
+    Pre,
+    Prepare { prepare: PbftRequest },
+    Commit { commit: PbftRequest },
+    Complete { req: PbftRequest },
+    Fail
+}
+
+#[derive(Clone, Debug)]
+struct PBFTPartyInfo {
+    /// Number of times the message has been tried.
+    nretries: usize,
+    /// When to send the next message.
+    when: Instant,
+    /// Latest phase for a message that has been observed from this party.
+    phase: PartyPhase,
+    /// Whether we need to send an acknowledgement to this party.
+    send_ack: Option<PbftAckState>
+}
+
+/// Outbound message structure for the Castro-Liskov PBFT consensus
+/// protocol.
+pub struct PBFTOutbound<RoundID> {
+    round: PhantomData<RoundID>,
+    /// Retry configuration.
+    retry: Retry,
+    /// My phase.
+    phase: LocalPhase,
+    /// State of all parties.
+    parties: Vec<PBFTPartyInfo>,
+    /// Parties that need a message sent.
+    active: BitVec,
+    /// Pending acknowledgements.
+    acks: BitVec
+}
+
+/// Iterator for [PBFTOutbound].
+pub struct PBFTOutboundIter {
+    inner: IntoIter<PbftMsg, BitVec>
+}
+
+impl From<usize> for OutboundPartyIdx {
+    #[inline]
+    fn from(val: usize) -> Self {
+        OutboundPartyIdx(val)
+    }
+}
+
+impl From<OutboundPartyIdx> for usize {
+    #[inline]
+    fn from(val: OutboundPartyIdx) -> usize {
+        val.0
+    }
+}
+
+impl Iterator for PBFTOutboundIter {
+    type Item = OutboundGroup<PbftMsg>;
+
+    #[inline]
+    fn nth(
+        &mut self,
+        n: usize
+    ) -> Option<OutboundGroup<PbftMsg>> {
+        self.inner
+            .nth(n)
+            .map(|(msg, bitvec)| OutboundGroup::create(bitvec, msg))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+
+    #[inline]
+    fn next(&mut self) -> Option<OutboundGroup<PbftMsg>> {
+        self.inner
+            .next()
+            .map(|(msg, bitvec)| OutboundGroup::create(bitvec, msg))
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.inner.count()
+    }
+}
+
+impl FusedIterator for PBFTOutboundIter {}
+
+impl ExactSizeIterator for PBFTOutboundIter {
+    #[inline]
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+impl<RoundID> PBFTOutbound<RoundID> {
+    #[inline]
+    fn new(
+        nparties: usize,
+        retry: Retry
+    ) -> Self {
+        let info = PBFTPartyInfo {
+            when: Instant::now(),
+            phase: PartyPhase::Prepare,
+            nretries: 0,
+            send_ack: None
+        };
+
+        debug!(target: "pbft-outbound",
+               "creating outbound with {} parties",
+               nparties);
+
+        PBFTOutbound {
+            round: PhantomData,
+            parties: vec![info; nparties],
+            phase: LocalPhase::Pre,
+            retry: retry,
+            active: bitvec![0; nparties],
+            acks: bitvec![0; nparties]
+        }
+    }
+
+    fn recv_prepare(
+        &mut self,
+        party_idx: usize
+    ) {
+        // If we're in prepare or earlier, we need to send an
+        // acknowledgement; otherwise, our status update automatically
+        // counts as one.
+        if let LocalPhase::Pre | LocalPhase::Prepare { .. } = self.phase {
+            match self.parties[party_idx].phase {
+                PartyPhase::Prepare => {
+                    trace!(target: "pbft-outbound",
+                           "marking party (index {}) as needing prepare ack",
+                           party_idx);
+
+                    self.parties[party_idx].send_ack =
+                        Some(PbftAckState::Prepare);
+                    self.acks.set(party_idx, true);
+                }
+                _ => {
+                    trace!(target: "pbft-outbound",
+                           "party (index {}) is already past prepare phase",
+                           party_idx);
+                }
+            }
+        }
+    }
+
+    fn recv_commit(
+        &mut self,
+        party_idx: usize
+    ) {
+        debug!(target: "pbft-outbound",
+               "logging commit message from party (index {})",
+               party_idx);
+
+        // Advance party to the commit phase if they aren't there already.
+        if let PartyPhase::Prepare = self.parties[party_idx].phase {
+            trace!(target: "pbft-outbound",
+                   "recording party (index {}) as being in commit phase",
+                   party_idx);
+
+            self.parties[party_idx].phase = PartyPhase::Commit;
+        }
+
+        // If we're in a phase before commit, this cancels every
+        // pending send.
+        if let LocalPhase::Pre | LocalPhase::Prepare { .. } = self.phase {
+            trace!(target: "pbft-outbound",
+                   "marking party (index {}) as inactive",
+                   party_idx);
+
+            self.parties[party_idx].nretries = 0;
+            self.active.set(party_idx, false);
+        }
+
+        // If we're in commit or earlier, we need to send an
+        // acknowledgement; otherwise, our status update automatically
+        // counts as one.
+        if let LocalPhase::Pre |
+        LocalPhase::Prepare { .. } |
+        LocalPhase::Commit { .. } = self.phase
+        {
+            match self.parties[party_idx].phase {
+                PartyPhase::Prepare | PartyPhase::Commit => {
+                    trace!(target: "pbft-outbound",
+                           "marking party (index {}) as needing commit ack",
+                           party_idx);
+
+                    self.parties[party_idx].send_ack =
+                        Some(PbftAckState::Commit);
+                    self.acks.set(party_idx, true);
+                }
+                _ => {
+                    trace!(target: "pbft-outbound",
+                           "party (index {}) is already past commit phase",
+                           party_idx);
+                }
+            }
+        }
+    }
+
+    fn recv_complete(
+        &mut self,
+        party_idx: usize
+    ) {
+        debug!(target: "pbft-outbound",
+               "logging complete message from party (index {})",
+               party_idx);
+
+        // No matter what, we send an acknowledgement.
+        self.parties[party_idx].send_ack = Some(PbftAckState::Complete);
+        self.acks.set(party_idx, true);
+
+        // Advance to the commit phase if we aren't there already.
+        if let PartyPhase::Prepare | PartyPhase::Commit =
+            self.parties[party_idx].phase
+        {
+            trace!(target: "pbft-outbound",
+                   "recording party (index {}) as being in resolved phase",
+                   party_idx);
+
+            self.parties[party_idx].phase = PartyPhase::Resolved;
+        }
+
+        // If we're in a phase before resolved, this cancels every
+        // pending send.
+        if let LocalPhase::Pre |
+        LocalPhase::Prepare { .. } |
+        LocalPhase::Commit { .. } = self.phase
+        {
+            trace!(target: "pbft-outbound",
+                   "marking party (index {}) as inactive",
+                   party_idx);
+
+            self.parties[party_idx].nretries = 0;
+            self.active.set(party_idx, false);
+        }
+    }
+
+    fn recv_fail(
+        &mut self,
+        party_idx: usize
+    ) {
+        debug!(target: "pbft-outbound",
+               "logging fail message from party (index {})",
+               party_idx);
+
+        // No matter what, we send an acknowledgement.
+        self.parties[party_idx].send_ack = Some(PbftAckState::Fail);
+        self.acks.set(party_idx, true);
+
+        // Advance to the commit phase if we aren't there already.
+        if let PartyPhase::Prepare | PartyPhase::Commit =
+            self.parties[party_idx].phase
+        {
+            trace!(target: "pbft-outbound",
+                   "recording party (index {}) as being in resolved phase",
+                   party_idx);
+
+            self.parties[party_idx].phase = PartyPhase::Resolved;
+        }
+
+        // If we're in a phase before resolved, this cancels every
+        // pending send.
+        if let LocalPhase::Pre |
+        LocalPhase::Prepare { .. } |
+        LocalPhase::Commit { .. } = self.phase
+        {
+            trace!(target: "pbft-outbound",
+                   "marking party (index {}) as inactive",
+                   party_idx);
+
+            self.parties[party_idx].nretries = 0;
+            self.active.set(party_idx, false);
+        }
+    }
+
+    fn recv_prepare_ack(
+        &mut self,
+        party_idx: usize
+    ) {
+        match &self.phase {
+            // We're in the prepare phase; remove the party from the
+            // active set.
+            LocalPhase::Prepare { .. } => {
+                trace!(target: "pbft-outbound",
+                       "party (index {}) acknowledged our prepare message",
+                       party_idx);
+
+                self.parties[party_idx].nretries = 0;
+                self.active.set(party_idx, false);
+            }
+            // Should not get a prepare acknowledgement before the
+            // prepare phase.
+            LocalPhase::Pre => {
+                warn!(target: "pbft-outbound",
+                      "premature prepare acknowledgement from party (index {})",
+                      party_idx);
+            }
+            // We're already past the prepare phase; ignore.
+            _ => {
+                trace!(target: "pbft-outbound",
+                       "ignoring prepare acknowledgement from party (index {})",
+                       party_idx);
+            }
+        }
+    }
+
+    fn recv_commit_ack(
+        &mut self,
+        party_idx: usize
+    ) {
+        match &self.phase {
+            // We're in the prepare phase; remove the party from the
+            // active set.
+            LocalPhase::Commit { .. } => {
+                trace!(target: "pbft-outbound",
+                       "party (index {}) acknowledged our commit message",
+                       party_idx);
+
+                self.parties[party_idx].nretries = 0;
+                self.active.set(party_idx, false);
+            }
+            // Should not get a commit acknowledgement before the commit phase.
+            LocalPhase::Pre | LocalPhase::Prepare { .. } => {
+                warn!(target: "pbft-outbound",
+                      "premature commit acknowledgement from party (index {})",
+                      party_idx);
+            }
+            // We're already past the prepare phase; ignore.
+            _ => {
+                trace!(target: "pbft-outbound",
+                       "ignoring commit acknowledgement from party (index {})",
+                       party_idx);
+            }
+        }
+    }
+
+    fn recv_complete_ack(
+        &mut self,
+        party_idx: usize
+    ) {
+        match &self.phase {
+            // We're in the prepare phase; remove the party from the
+            // active set.
+            LocalPhase::Complete { .. } => {
+                trace!(target: "pbft-outbound",
+                       "party (index {}) acknowledged our commit message",
+                       party_idx);
+
+                self.parties[party_idx].phase = PartyPhase::Acknowledged;
+                self.parties[party_idx].nretries = 0;
+                self.active.set(party_idx, false);
+            }
+            // Should not get a commit acknowledgement before the commit phase.
+            LocalPhase::Pre |
+            LocalPhase::Prepare { .. } |
+            LocalPhase::Commit { .. } => {
+                warn!(target: "pbft-outbound",
+                      "premature complete acknowledgement from party (index {})",
+                      party_idx);
+            }
+            // We're already past the prepare phase; ignore.
+            LocalPhase::Fail => {
+                warn!(target: "pbft-outbound",
+                      "incorrect fail acknowledgement from party (index {})",
+                      party_idx);
+            }
+        }
+    }
+
+    fn recv_fail_ack(
+        &mut self,
+        party_idx: usize
+    ) {
+        match &self.phase {
+            // We're in the prepare phase; remove the party from the
+            // active set.
+            LocalPhase::Fail => {
+                trace!(target: "pbft-outbound",
+                       "party (index {}) acknowledged our fail message",
+                       party_idx);
+
+                self.parties[party_idx].phase = PartyPhase::Acknowledged;
+                self.parties[party_idx].nretries = 0;
+                self.active.set(party_idx, false);
+            }
+            // Should not get a commit acknowledgement before the commit phase.
+            LocalPhase::Pre |
+            LocalPhase::Prepare { .. } |
+            LocalPhase::Commit { .. } => {
+                warn!(target: "pbft-outbound",
+                      "premature complete acknowledgement from party (index {})",
+                      party_idx);
+            }
+            // We're already past the prepare phase; ignore.
+            LocalPhase::Complete { .. } => {
+                warn!(target: "pbft-outbound",
+                      "incorrect fail acknowledgement from party (index {})",
+                      party_idx);
+            }
+        }
+    }
+}
+
+impl<RoundID> Outbound<RoundID, PbftMsg> for PBFTOutbound<RoundID>
+where
+    RoundID: Clone + Display + Ord + From<u128> + Into<u128>
+{
+    type CollectOutboundError = Infallible;
+    type Config = PBFTOutboundConfig;
+    type PartyID = OutboundPartyIdx;
+    type RecvError = Infallible;
+
+    #[inline]
+    fn create(
+        nparties: usize,
+        config: PBFTOutboundConfig
+    ) -> Self {
+        let retry = config.take();
+
+        PBFTOutbound::new(nparties, retry)
+    }
+
+    fn recv(
+        &mut self,
+        msg: &PbftContent,
+        party: &OutboundPartyIdx
+    ) -> Result<(), Self::RecvError> {
+        let party_idx: usize = party.clone().into();
+        let (ack, update) = match msg {
+            PbftContent::UpdateAck(PbftUpdateAck { update, ack }) => {
+                (Some(ack), Some(update))
+            }
+            PbftContent::Update(update) => (None, Some(update)),
+            PbftContent::Ack(ack) => (Some(ack), None)
+        };
+
+        match update {
+            Some(PbftStateUpdate::Prepare(_)) => self.recv_prepare(party_idx),
+            Some(PbftStateUpdate::Commit(_)) => self.recv_commit(party_idx),
+            Some(PbftStateUpdate::Complete(_)) => self.recv_complete(party_idx),
+            Some(PbftStateUpdate::Fail(_)) => self.recv_fail(party_idx),
+            None => {}
+        }
+
+        match ack {
+            Some(PbftAckState::Prepare) => self.recv_prepare_ack(party_idx),
+            Some(PbftAckState::Commit) => self.recv_commit_ack(party_idx),
+            Some(PbftAckState::Complete) => self.recv_complete_ack(party_idx),
+            Some(PbftAckState::Fail) => self.recv_fail_ack(party_idx),
+            None => {}
+        }
+
+        Ok(())
+    }
+
+    fn collect_outbound<F>(
+        &mut self,
+        round: RoundID,
+        mut func: F
+    ) -> Result<Option<Instant>, Self::CollectOutboundError>
+    where
+        F: FnMut(OutboundGroup<PbftMsg>) {
+        let nparties = self.parties.len();
+        let mut msgs: HashMap<PbftMsg, BitVec> =
+            HashMap::with_capacity(nparties);
+        let now = Instant::now();
+        let mut earliest = None;
+        let round: u128 = round.into();
+
+        debug!(target: "pbft-outbound",
+               "collecting pending outbound messages");
+
+        let sends = self.active.clone() | &self.acks;
+
+        // Clear out acknowledgements; we will only send one, and we
+        // will always send them here.
+        self.acks.fill(false);
+
+        for i in sends.iter_ones() {
+            let req = if self.active[i] {
+                let party = &mut self.parties[i];
+
+                if party.when <= now {
+                    trace!(target: "pbft-outbound",
+                           "party (index {}) is ready to send",
+                           i);
+
+                    let delay = self.retry.retry_delay(party.nretries);
+
+                    trace!(target: "pbft-outbound",
+                           "party (index {}) next send in {}.{:03}s",
+                           i, delay.as_secs(), delay.subsec_millis());
+
+                    party.nretries += 1;
+                    party.when = now + delay;
+                }
+
+                match earliest {
+                    Some(when) if when > party.when => {
+                        earliest = Some(party.when)
+                    }
+                    None => earliest = Some(party.when),
+                    _ => {}
+                }
+
+                // Generate the outgoing request
+                match &self.phase {
+                    LocalPhase::Pre => None,
+                    LocalPhase::Prepare { prepare } => {
+                        Some(PbftStateUpdate::Prepare(prepare.clone()))
+                    }
+                    LocalPhase::Commit { commit } => {
+                        Some(PbftStateUpdate::Commit(commit.clone()))
+                    }
+                    LocalPhase::Complete { req } => {
+                        Some(PbftStateUpdate::Complete(req.clone()))
+                    }
+                    LocalPhase::Fail => Some(PbftStateUpdate::Fail(Null))
+                }
+            } else {
+                trace!(target: "pbft-outbound",
+                       "{} not active",
+                       i);
+
+                None
+            };
+
+            let ack = self.parties[i].send_ack;
+
+            self.parties[i].send_ack = None;
+
+            match (req, ack) {
+                (Some(req), Some(ack)) => {
+                    let update_ack = PbftUpdateAck {
+                        ack: ack,
+                        update: req
+                    };
+                    let content = PbftContent::UpdateAck(update_ack);
+
+                    debug!(target: "pbft-outbound",
+                           "sending state update and ack to party (index {})",
+                           i);
+
+                    match msgs.entry(PbftMsg::create(round, content)) {
+                        Entry::Occupied(mut ent) => ent.get_mut().set(i, true),
+                        Entry::Vacant(ent) => {
+                            let mut bitvec = bitvec![0; nparties];
+
+                            bitvec.set(i, true);
+
+                            ent.insert(bitvec);
+                        }
+                    }
+                }
+                (Some(req), None) => {
+                    let content = PbftContent::Update(req);
+
+                    debug!(target: "pbft-outbound",
+                           "sending state update to party (index {})",
+                           i);
+
+                    match msgs.entry(PbftMsg::create(round, content)) {
+                        Entry::Occupied(mut ent) => ent.get_mut().set(i, true),
+                        Entry::Vacant(ent) => {
+                            let mut bitvec = bitvec![0; nparties];
+
+                            bitvec.set(i, true);
+
+                            ent.insert(bitvec);
+                        }
+                    }
+                }
+                (None, Some(ack)) => {
+                    let content = PbftContent::Ack(ack);
+
+                    debug!(target: "pbft-outbound",
+                           "sending bare ack to party (index {})",
+                           i);
+
+                    match msgs.entry(PbftMsg::create(round, content)) {
+                        Entry::Occupied(mut ent) => ent.get_mut().set(i, true),
+                        Entry::Vacant(ent) => {
+                            let mut bitvec = bitvec![0; nparties];
+
+                            bitvec.set(i, true);
+
+                            ent.insert(bitvec);
+                        }
+                    }
+                }
+                _ => {
+                    error!(target: "pbft-outbound",
+                           "should not see no-content message case");
+                }
+            }
+        }
+
+        for (msg, parties) in msgs.into_iter() {
+            func(OutboundGroup::create(parties, msg))
+        }
+
+        Ok(earliest)
+    }
+
+    fn finished(&self) -> bool {
+        for party in self.parties.iter() {
+            match (party.phase, party.send_ack) {
+                (PartyPhase::Acknowledged, None) => {}
+                _ => return false
+            }
+        }
+
+        true
+    }
+}
+
+impl<RoundID> PBFTOutboundSend<PbftRequest> for PBFTOutbound<RoundID> {
+    fn send_prepare(
+        &mut self,
+        req: &PbftRequest
+    ) {
+        debug!(target: "pbft-outbound",
+               "requested to send prepare messages");
+
+        // Smoke check: ensure that we're in the right phase.
+        match &self.phase {
+            LocalPhase::Pre => {
+                let now = Instant::now();
+
+                self.phase = LocalPhase::Prepare {
+                    prepare: req.clone()
+                };
+
+                trace!(target: "pbft-outbound",
+                       "set local phase to {}",
+                       self.phase);
+
+                for i in 0..self.parties.len() {
+                    match &self.parties[i].phase {
+                        PartyPhase::Prepare => {
+                            trace!(target: "pbft-outbound",
+                                   "setting party (index {}) to active",
+                                   i);
+
+                            // Reset the parties retries and schedule it
+                            // for immediate sending.
+                            let party = &mut self.parties[i];
+
+                            party.nretries = 0;
+                            party.when = now;
+                            self.active.set(i, true);
+                        }
+                        // Party is in a later phase already, so
+                        // nothing happens.
+                        phase => {
+                            trace!(target: "pbft-outbound",
+                                   "party (index {}) is already in phase {}",
+                                   i, phase);
+                        }
+                    }
+                }
+            }
+            // Shouldn't be calling this from a different phase.
+            phase => {
+                error!(target: "pbft-outbound",
+                       "calling send_prepare from wrong phase ({})",
+                       phase);
+            }
+        }
+    }
+
+    fn send_commit(
+        &mut self,
+        req: &PbftRequest
+    ) {
+        debug!(target: "pbft-outbound",
+               "requested to send commit messages");
+
+        // Smoke check: ensure that we're in the right phase.
+        match &self.phase {
+            LocalPhase::Pre | LocalPhase::Prepare { .. } => {
+                let now = Instant::now();
+
+                self.phase = LocalPhase::Commit {
+                    commit: req.clone()
+                };
+
+                trace!(target: "pbft-outbound",
+                       "set local phase to {}",
+                       self.phase);
+
+                for i in 0..self.parties.len() {
+                    match &self.parties[i].phase {
+                        PartyPhase::Prepare | PartyPhase::Commit => {
+                            trace!(target: "pbft-outbound",
+                                   "setting party (index {}) to active",
+                                   i);
+
+                            // Reset the parties retries and schedule it
+                            // for immediate sending.
+                            let party = &mut self.parties[i];
+
+                            party.nretries = 0;
+                            party.when = now;
+                            self.active.set(i, true);
+
+                            if party.send_ack == Some(PbftAckState::Prepare) {
+                                party.send_ack = None;
+                                self.acks.set(i, false);
+                            }
+                        }
+                        // Party is in a later phase already, so
+                        // nothing happens.
+                        phase => {
+                            trace!(target: "pbft-outbound",
+                                   "party (index {}) is already in phase {}",
+                                   i, phase);
+                        }
+                    }
+                }
+            }
+            // Shouldn't be calling this from a different phase.
+            phase => {
+                error!(target: "pbft-outbound",
+                       "calling send_commit from wrong phase ({})",
+                       phase);
+            }
+        }
+    }
+
+    fn send_complete(
+        &mut self,
+        req: &PbftRequest
+    ) {
+        debug!(target: "pbft-outbound",
+               "requested to send complete messages");
+
+        // Smoke check: ensure that we're in the right phase.
+        match &self.phase {
+            LocalPhase::Pre |
+            LocalPhase::Prepare { .. } |
+            LocalPhase::Commit { .. } => {
+                let now = Instant::now();
+
+                self.phase = LocalPhase::Complete { req: req.clone() };
+
+                trace!(target: "pbft-outbound",
+                       "set local phase to {}",
+                       self.phase);
+
+                for i in 0..self.parties.len() {
+                    match &mut self.parties[i].phase {
+                        PartyPhase::Prepare |
+                        PartyPhase::Commit |
+                        PartyPhase::Resolved => {
+                            trace!(target: "pbft-outbound",
+                                   "setting party (index {}) to active",
+                                   i);
+
+                            // Reset the parties retries and schedule it
+                            // for immediate sending.
+                            let party = &mut self.parties[i];
+
+                            party.nretries = 0;
+                            party.when = now;
+                            self.active.set(i, true);
+
+                            match party.send_ack {
+                                Some(PbftAckState::Prepare) |
+                                Some(PbftAckState::Commit) => {
+                                    party.send_ack = None;
+                                    self.acks.set(i, false);
+                                }
+                                _ => {}
+                            }
+                        }
+                        // Party is in a later phase already, so
+                        // nothing happens.
+                        phase => {
+                            trace!(target: "pbft-outbound",
+                                   "party (index {}) is already in phase {}",
+                                   i, phase);
+                        }
+                    }
+                }
+            }
+            // Shouldn't be calling this from a different phase.
+            phase => {
+                error!(target: "pbft-outbound",
+                       "calling send_complete from wrong phase ({})",
+                       phase);
+            }
+        }
+    }
+
+    fn send_fail(&mut self) {
+        debug!(target: "pbft-outbound",
+               "requested to send fail messages");
+
+        // Smoke check: ensure that we're in the right phase.
+        match &self.phase {
+            LocalPhase::Pre |
+            LocalPhase::Prepare { .. } |
+            LocalPhase::Commit { .. } => {
+                let now = Instant::now();
+
+                self.phase = LocalPhase::Fail;
+
+                trace!(target: "pbft-outbound",
+                       "set local phase to {}",
+                       self.phase);
+
+                for i in 0..self.parties.len() {
+                    match &mut self.parties[i].phase {
+                        PartyPhase::Prepare |
+                        PartyPhase::Commit |
+                        PartyPhase::Resolved => {
+                            trace!(target: "pbft-outbound",
+                                   "setting party (index {}) to active",
+                                   i);
+
+                            // Reset the parties retries and schedule it
+                            // for immediate sending.
+                            let party = &mut self.parties[i];
+
+                            party.nretries = 0;
+                            party.when = now;
+                            self.active.set(i, true);
+
+                            match party.send_ack {
+                                Some(PbftAckState::Prepare) |
+                                Some(PbftAckState::Commit) => {
+                                    party.send_ack = None;
+                                    self.acks.set(i, false);
+                                }
+                                _ => {}
+                            }
+                        }
+                        // Party is in a later phase already, so
+                        // nothing happens.
+                        phase => {
+                            trace!(target: "pbft-outbound",
+                                   "party (index {}) is already in phase {}",
+                                   i, phase);
+                        }
+                    }
+                }
+            }
+            // Shouldn't be calling this from a different phase.
+            phase => {
+                error!(target: "pbft-outbound",
+                       "calling send_fail from wrong phase ({})",
+                       phase);
+            }
+        }
+    }
+}
+
+impl Display for PartyPhase {
+    fn fmt(
+        &self,
+        f: &mut Formatter<'_>
+    ) -> Result<(), Error> {
+        match self {
+            PartyPhase::Prepare => write!(f, "prepare"),
+            PartyPhase::Commit => write!(f, "commit"),
+            PartyPhase::Resolved => write!(f, "resolved"),
+            PartyPhase::Acknowledged => write!(f, "acknowledged")
+        }
+    }
+}
+
+impl Display for LocalPhase {
+    fn fmt(
+        &self,
+        f: &mut Formatter<'_>
+    ) -> Result<(), Error> {
+        match self {
+            LocalPhase::Pre => write!(f, "pre-prepare"),
+            LocalPhase::Prepare { .. } => write!(f, "prepare"),
+            LocalPhase::Commit { .. } => write!(f, "commit"),
+            LocalPhase::Complete { .. } => write!(f, "complete"),
+            LocalPhase::Fail => write!(f, "failed")
+        }
+    }
+}
+
+impl Display for OutboundPartyIdx {
+    fn fmt(
+        &self,
+        f: &mut Formatter<'_>
+    ) -> Result<(), Error> {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+use std::collections::HashSet;
+
+#[cfg(test)]
+use bitvec::order::Lsb0;
+
+#[cfg(test)]
+use crate::generated::req::PbftView;
+
+#[test]
+fn test_empty_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![].drain(..).collect();
+    let mut actual = HashSet::new();
+
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let ack = PbftContent::Ack(PbftAckState::Prepare);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_prepare(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_collect_outbound_twice() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let ack = PbftContent::Ack(PbftAckState::Prepare);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_prepare(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual);
+
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![].drain(..).collect();
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_recv_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_prepare(&req);
+    outbound.recv_prepare(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare(0);
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_recv_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Commit);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_prepare(&req);
+    outbound.recv_commit(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Commit);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit(0);
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_recv_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Complete);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_prepare(&req);
+    outbound.recv_complete(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Complete);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete(0);
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_recv_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Fail);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_prepare(&req);
+    outbound.recv_fail(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Fail);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail(0);
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_recv_prepare_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_prepare(&req);
+    outbound.recv_prepare_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_ack_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_prepare_ack(0);
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_recv_commit_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_prepare(&req);
+    outbound.recv_commit_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_ack_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_commit_ack(0);
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_recv_complete_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_prepare(&req);
+    outbound.recv_complete_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_ack_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_complete_ack(0);
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_recv_fail_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_prepare(&req);
+    outbound.recv_fail_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_ack_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_fail_ack(0);
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_recv_prepare_recv_prepare_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Prepare);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_prepare(&req);
+    outbound.recv_prepare(0);
+    outbound.recv_prepare_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_recv_prepare_ack_recv_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Prepare);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_prepare(&req);
+    outbound.recv_prepare_ack(0);
+    outbound.recv_prepare(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_ack_send_prepare_recv_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare_ack(0);
+    outbound.send_prepare(&req);
+    outbound.recv_prepare(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_send_prepare_recv_prepare_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Prepare);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare(0);
+    outbound.send_prepare(&req);
+    outbound.recv_prepare_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_ack_recv_prepare_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare_ack(0);
+    outbound.recv_prepare(0);
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_recv_prepare_ack_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare(0);
+    outbound.recv_prepare_ack(0);
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_recv_prepare_recv_commit_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_prepare(&req);
+    outbound.recv_prepare(0);
+    outbound.recv_commit_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_recv_commit_ack_recv_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_prepare(&req);
+    outbound.recv_commit_ack(0);
+    outbound.recv_prepare(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_ack_send_prepare_recv_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit_ack(0);
+    outbound.send_prepare(&req);
+    outbound.recv_prepare(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_send_prepare_recv_commit_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare(0);
+    outbound.send_prepare(&req);
+    outbound.recv_commit_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_ack_recv_prepare_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit_ack(0);
+    outbound.recv_prepare(0);
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_recv_commit_ack_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare(0);
+    outbound.recv_commit_ack(0);
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_recv_prepare_recv_complete_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_prepare(&req);
+    outbound.recv_prepare(0);
+    outbound.recv_complete_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_recv_complete_ack_recv_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_prepare(&req);
+    outbound.recv_complete_ack(0);
+    outbound.recv_prepare(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_ack_send_prepare_recv_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete_ack(0);
+    outbound.send_prepare(&req);
+    outbound.recv_prepare(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_send_prepare_recv_complete_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare(0);
+    outbound.send_prepare(&req);
+    outbound.recv_complete_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_ack_recv_prepare_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete_ack(0);
+    outbound.recv_prepare(0);
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_recv_complete_ack_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare(0);
+    outbound.recv_complete_ack(0);
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_recv_prepare_recv_fail_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_prepare(&req);
+    outbound.recv_prepare(0);
+    outbound.recv_fail_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_prepare_recv_fail_ack_recv_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_prepare(&req);
+    outbound.recv_fail_ack(0);
+    outbound.recv_prepare(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_ack_send_prepare_recv_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail_ack(0);
+    outbound.send_prepare(&req);
+    outbound.recv_prepare(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_send_prepare_recv_fail_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare(0);
+    outbound.send_prepare(&req);
+    outbound.recv_fail_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_ack_recv_prepare_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail_ack(0);
+    outbound.recv_prepare(0);
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_recv_fail_ack_send_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Prepare(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Prepare,
+        update: PbftStateUpdate::Prepare(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare(0);
+    outbound.recv_fail_ack(0);
+    outbound.send_prepare(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let ack = PbftContent::Ack(PbftAckState::Commit);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_commit(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_collect_outbound_twice() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let ack = PbftContent::Ack(PbftAckState::Commit);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_commit(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual);
+
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![].drain(..).collect();
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_recv_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_commit(&req);
+    outbound.recv_prepare(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_prepare(0);
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_recv_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_commit(&req);
+    outbound.recv_commit(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit(0);
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_recv_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Complete);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_commit(&req);
+    outbound.recv_complete(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Complete);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete(0);
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_recv_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Fail);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_commit(&req);
+    outbound.recv_fail(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Fail);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail(0);
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_recv_prepare_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_commit(&req);
+    outbound.recv_prepare_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_ack_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_prepare_ack(0);
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_recv_commit_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_commit(&req);
+    outbound.recv_commit_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_ack_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_commit_ack(0);
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_recv_complete_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_commit(&req);
+    outbound.recv_complete_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_ack_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_complete_ack(0);
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_recv_fail_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_commit(&req);
+    outbound.recv_fail_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_ack_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_fail_ack(0);
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_recv_commit_recv_prepare_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_commit(&req);
+    outbound.recv_commit(0);
+    outbound.recv_prepare_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_recv_prepare_ack_recv_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_commit(&req);
+    outbound.recv_prepare_ack(0);
+    outbound.recv_commit(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_ack_send_commit_recv_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare_ack(0);
+    outbound.send_commit(&req);
+    outbound.recv_commit(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_send_commit_recv_prepare_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit(0);
+    outbound.send_commit(&req);
+    outbound.recv_prepare_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_ack_recv_commit_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare_ack(0);
+    outbound.recv_commit(0);
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_recv_prepare_ack_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit(0);
+    outbound.recv_prepare_ack(0);
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_recv_commit_recv_commit_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Commit);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_commit(&req);
+    outbound.recv_commit(0);
+    outbound.recv_commit_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_recv_commit_ack_recv_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Commit);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_commit(&req);
+    outbound.recv_commit_ack(0);
+    outbound.recv_commit(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_ack_send_commit_recv_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit_ack(0);
+    outbound.send_commit(&req);
+    outbound.recv_commit(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_send_commit_recv_commit_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Commit);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit(0);
+    outbound.send_commit(&req);
+    outbound.recv_commit_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_ack_recv_commit_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit_ack(0);
+    outbound.recv_commit(0);
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_recv_commit_ack_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit(0);
+    outbound.recv_commit_ack(0);
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_recv_commit_recv_complete_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_commit(&req);
+    outbound.recv_commit(0);
+    outbound.recv_complete_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_recv_complete_ack_recv_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_commit(&req);
+    outbound.recv_complete_ack(0);
+    outbound.recv_commit(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_ack_send_commit_recv_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete_ack(0);
+    outbound.send_commit(&req);
+    outbound.recv_commit(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_send_commit_recv_complete_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit(0);
+    outbound.send_commit(&req);
+    outbound.recv_complete_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_ack_recv_commit_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete_ack(0);
+    outbound.recv_commit(0);
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_recv_complete_ack_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit(0);
+    outbound.recv_complete_ack(0);
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_recv_commit_recv_fail_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_commit(&req);
+    outbound.recv_commit(0);
+    outbound.recv_fail_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_commit_recv_fail_ack_recv_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_commit(&req);
+    outbound.recv_fail_ack(0);
+    outbound.recv_commit(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_ack_send_commit_recv_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail_ack(0);
+    outbound.send_commit(&req);
+    outbound.recv_commit(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_send_commit_recv_fail_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit(0);
+    outbound.send_commit(&req);
+    outbound.recv_fail_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_ack_recv_commit_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail_ack(0);
+    outbound.recv_commit(0);
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_recv_fail_ack_send_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Commit(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Commit,
+        update: PbftStateUpdate::Commit(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit(0);
+    outbound.recv_fail_ack(0);
+    outbound.send_commit(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let ack = PbftContent::Ack(PbftAckState::Complete);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_complete(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_collect_outbound_twice() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let ack = PbftContent::Ack(PbftAckState::Complete);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_complete(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual);
+
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![].drain(..).collect();
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_recv_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_complete(&req);
+    outbound.recv_prepare(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_prepare(0);
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_recv_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_complete(&req);
+    outbound.recv_commit(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_commit(0);
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_recv_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_complete(&req);
+    outbound.recv_complete(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete(0);
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_recv_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_complete(&req);
+    outbound.recv_fail(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail(0);
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_recv_prepare_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_complete(&req);
+    outbound.recv_prepare_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_ack_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_prepare_ack(0);
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_recv_commit_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_complete(&req);
+    outbound.recv_commit_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_ack_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_commit_ack(0);
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_recv_complete_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_complete(&req);
+    outbound.recv_complete_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_ack_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_complete_ack(0);
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_recv_fail_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_complete(&req);
+    outbound.recv_fail_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_ack_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_fail_ack(0);
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_recv_complete_recv_prepare_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_complete(&req);
+    outbound.recv_complete(0);
+    outbound.recv_prepare_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_recv_prepare_ack_recv_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_complete(&req);
+    outbound.recv_prepare_ack(0);
+    outbound.recv_complete(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_ack_send_complete_recv_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare_ack(0);
+    outbound.send_complete(&req);
+    outbound.recv_complete(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_send_complete_recv_prepare_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete(0);
+    outbound.send_complete(&req);
+    outbound.recv_prepare_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_ack_recv_complete_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare_ack(0);
+    outbound.recv_complete(0);
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_recv_prepare_ack_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete(0);
+    outbound.recv_prepare_ack(0);
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_recv_complete_recv_commit_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_complete(&req);
+    outbound.recv_complete(0);
+    outbound.recv_commit_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_recv_commit_ack_recv_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_complete(&req);
+    outbound.recv_commit_ack(0);
+    outbound.recv_complete(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_ack_send_complete_recv_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit_ack(0);
+    outbound.send_complete(&req);
+    outbound.recv_complete(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_send_complete_recv_commit_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete(0);
+    outbound.send_complete(&req);
+    outbound.recv_commit_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_ack_recv_complete_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit_ack(0);
+    outbound.recv_complete(0);
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_recv_commit_ack_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete(0);
+    outbound.recv_commit_ack(0);
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_recv_complete_recv_complete_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Complete);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_complete(&req);
+    outbound.recv_complete(0);
+    outbound.recv_complete_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_recv_complete_ack_recv_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Complete);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_complete(&req);
+    outbound.recv_complete_ack(0);
+    outbound.recv_complete(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_ack_send_complete_recv_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete_ack(0);
+    outbound.send_complete(&req);
+    outbound.recv_complete(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_send_complete_recv_complete_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::Ack(PbftAckState::Complete);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete(0);
+    outbound.send_complete(&req);
+    outbound.recv_complete_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_ack_recv_complete_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete_ack(0);
+    outbound.recv_complete(0);
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_recv_complete_ack_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete(0);
+    outbound.recv_complete_ack(0);
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_recv_complete_recv_fail_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_complete(&req);
+    outbound.recv_complete(0);
+    outbound.recv_fail_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_complete_recv_fail_ack_recv_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_complete(&req);
+    outbound.recv_fail_ack(0);
+    outbound.recv_complete(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_ack_send_complete_recv_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail_ack(0);
+    outbound.send_complete(&req);
+    outbound.recv_complete(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_send_complete_recv_fail_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete(0);
+    outbound.send_complete(&req);
+    outbound.recv_fail_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_ack_recv_complete_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail_ack(0);
+    outbound.recv_complete(0);
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_recv_fail_ack_send_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let req = PbftRequest::View(PbftView { id: vec![0; 64] });
+    let msg = PbftContent::Update(PbftStateUpdate::Complete(req.clone()));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Complete(req.clone())
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete(0);
+    outbound.recv_fail_ack(0);
+    outbound.send_complete(&req);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let ack = PbftContent::Ack(PbftAckState::Fail);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_fail(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_collect_outbound_twice() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let ack = PbftContent::Ack(PbftAckState::Fail);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_fail(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual);
+
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![].drain(..).collect();
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_recv_prepare_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_fail();
+    outbound.recv_prepare(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_prepare(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_recv_commit_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_fail();
+    outbound.recv_commit(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_commit(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_recv_complete_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Complete,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_recv_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_fail();
+    outbound.recv_fail(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_recv_prepare_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_fail();
+    outbound.recv_prepare_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_ack_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_prepare_ack(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_recv_commit_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_fail();
+    outbound.recv_commit_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_ack_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_commit_ack(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_recv_complete_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_fail();
+    outbound.recv_complete_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_ack_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_complete_ack(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_recv_fail_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.send_fail();
+    outbound.recv_fail_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_ack_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let msg = PbftMsg::create(round_id, msg);
+    let expected: HashSet<OutboundGroup<PbftMsg>> =
+        vec![OutboundGroup::create(bitvec![1, 1, 1, 1], msg.clone())]
+            .drain(..)
+            .collect();
+
+    outbound.recv_fail_ack(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_recv_fail_recv_prepare_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_fail();
+    outbound.recv_fail(0);
+    outbound.recv_prepare_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_recv_prepare_ack_recv_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_fail();
+    outbound.recv_prepare_ack(0);
+    outbound.recv_fail(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_ack_send_fail_recv_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare_ack(0);
+    outbound.send_fail();
+    outbound.recv_fail(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_send_fail_recv_prepare_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail(0);
+    outbound.send_fail();
+    outbound.recv_prepare_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_prepare_ack_recv_fail_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_prepare_ack(0);
+    outbound.recv_fail(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_recv_prepare_ack_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail(0);
+    outbound.recv_prepare_ack(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_recv_fail_recv_commit_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_fail();
+    outbound.recv_fail(0);
+    outbound.recv_commit_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_recv_commit_ack_recv_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_fail();
+    outbound.recv_commit_ack(0);
+    outbound.recv_fail(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_ack_send_fail_recv_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit_ack(0);
+    outbound.send_fail();
+    outbound.recv_fail(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_send_fail_recv_commit_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail(0);
+    outbound.send_fail();
+    outbound.recv_commit_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_commit_ack_recv_fail_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_commit_ack(0);
+    outbound.recv_fail(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_recv_commit_ack_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail(0);
+    outbound.recv_commit_ack(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_recv_fail_recv_complete_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_fail();
+    outbound.recv_fail(0);
+    outbound.recv_complete_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_recv_complete_ack_recv_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_fail();
+    outbound.recv_complete_ack(0);
+    outbound.recv_fail(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_ack_send_fail_recv_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete_ack(0);
+    outbound.send_fail();
+    outbound.recv_fail(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_send_fail_recv_complete_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail(0);
+    outbound.send_fail();
+    outbound.recv_complete_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_complete_ack_recv_fail_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_complete_ack(0);
+    outbound.recv_fail(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_recv_complete_ack_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail(0);
+    outbound.recv_complete_ack(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_recv_fail_recv_fail_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::Ack(PbftAckState::Fail);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_fail();
+    outbound.recv_fail(0);
+    outbound.recv_fail_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_send_fail_recv_fail_ack_recv_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::Ack(PbftAckState::Fail);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.send_fail();
+    outbound.recv_fail_ack(0);
+    outbound.recv_fail(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_ack_send_fail_recv_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail_ack(0);
+    outbound.send_fail();
+    outbound.recv_fail(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_send_fail_recv_fail_ack_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::Ack(PbftAckState::Fail);
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail(0);
+    outbound.send_fail();
+    outbound.recv_fail_ack(0);
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_ack_recv_fail_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail_ack(0);
+    outbound.recv_fail(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}
+
+#[test]
+fn test_recv_fail_recv_fail_ack_send_fail_collect_outbound() {
+    let round_id = 7;
+    let mut outbound: PBFTOutbound<u128> =
+        PBFTOutbound::new(4, Retry::default());
+    let msg = PbftContent::Update(PbftStateUpdate::Fail(Null));
+    let msg = PbftMsg::create(round_id, msg);
+    let ack = PbftContent::UpdateAck(PbftUpdateAck {
+        ack: PbftAckState::Fail,
+        update: PbftStateUpdate::Fail(Null)
+    });
+    let ack = PbftMsg::create(round_id, ack);
+    let expected: HashSet<OutboundGroup<PbftMsg>> = vec![
+        OutboundGroup::create(bitvec![1, 0, 0, 0], ack.clone()),
+        OutboundGroup::create(bitvec![0, 1, 1, 1], msg.clone()),
+    ]
+    .drain(..)
+    .collect();
+
+    outbound.recv_fail(0);
+    outbound.recv_fail_ack(0);
+    outbound.send_fail();
+
+    let mut actual = HashSet::new();
+    outbound
+        .collect_outbound(round_id, |msg| {
+            actual.insert(msg);
+        })
+        .unwrap();
+
+    assert_eq!(expected, actual)
+}

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,0 +1,131 @@
+// Copyright © 2024 The Johns Hopkins Applied Physics Laboratory LLC.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU Affero General Public License,
+// version 3, as published by the Free Software Foundation.  If you
+// would like to purchase a commercial license for this software, please
+// contact APL’s Tech Transfer at 240-592-0817 or
+// techtransfer@jhuapl.edu.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+//! Top-level Castro-Liskov PBFT consensus protocol implementation.
+use std::convert::Infallible;
+use std::fmt::Display;
+use std::hash::Hash;
+use std::marker::PhantomData;
+
+use constellation_common::codec::DatagramCodec;
+use constellation_consensus_common::parties::StaticParties;
+use constellation_consensus_common::parties::StaticPartiesError;
+use constellation_consensus_common::proto::ConsensusProto;
+use constellation_consensus_common::proto::ConsensusProtoRounds;
+use constellation_consensus_common::round::SingleRound;
+use constellation_consensus_common::round::SingleRoundCreateError;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::config::PBFTConfig;
+use crate::config::PBFTProtoStateConfig;
+use crate::msgs::PbftMsg;
+use crate::outbound::OutboundPartyIdx;
+use crate::outbound::PBFTOutbound;
+use crate::state::PBFTProtoState;
+use crate::state::PBFTProtoStateCreateError;
+use crate::state::PBFTRoundStateCreateError;
+
+/// Castro-Liskov PBFT consensus protocol implementation.
+pub struct PBFTProto<RoundIDs, Party, PartyCodec>
+where
+    RoundIDs: Iterator,
+    RoundIDs::Item: Clone + Display + From<u128> + Into<u128> + Ord,
+    PartyCodec: Clone + DatagramCodec<Party>,
+    Party: Clone + Eq + Hash {
+    party: PhantomData<Party>,
+    round_ids: PhantomData<RoundIDs>,
+    party_codec: PartyCodec,
+    outbound_config: PBFTProtoStateConfig
+}
+
+impl<RoundIDs, Party, Codec> ConsensusProto<Party, Codec>
+    for PBFTProto<RoundIDs, Party, Codec>
+where
+    RoundIDs: Iterator,
+    RoundIDs::Item: Clone + Display + From<u128> + Into<u128> + Ord,
+    Party: Clone + Display + Eq + Hash,
+    Codec: Clone + DatagramCodec<Party>
+{
+    type Config = PBFTConfig;
+    type CreateError = Infallible;
+
+    fn create(
+        config: Self::Config,
+        codec: Codec
+    ) -> Result<Self, Self::CreateError> {
+        let outbound_config = config.take();
+
+        Ok(PBFTProto {
+            party: PhantomData,
+            round_ids: PhantomData,
+            party_codec: codec,
+            outbound_config: outbound_config
+        })
+    }
+}
+
+impl<RoundIDs, PartyID, Party, Codec>
+    ConsensusProtoRounds<
+        RoundIDs,
+        PartyID,
+        Party,
+        Codec,
+        StaticParties<PartyID>
+    > for PBFTProto<RoundIDs, Party, Codec>
+where
+    RoundIDs: Iterator,
+    RoundIDs::Item: Clone + Display + From<u128> + Into<u128> + Ord + Send,
+    PartyID: Clone + Display + Eq + Hash + From<usize> + Into<usize>,
+    Party: Clone + for<'a> Deserialize<'a> + Display + Eq + Hash + Serialize,
+    Codec: Clone + DatagramCodec<Party>
+{
+    type Msg = PbftMsg;
+    type Out = PBFTOutbound<RoundIDs::Item>;
+    type RoundPartyIdx = OutboundPartyIdx;
+    type Rounds = SingleRound<
+        PBFTProtoState<PartyID>,
+        RoundIDs,
+        PartyID,
+        PbftMsg,
+        PBFTOutbound<RoundIDs::Item>
+    >;
+    type RoundsError<PartiesErr> = SingleRoundCreateError<
+        PBFTProtoStateCreateError<PartiesErr, Codec::EncodeError>,
+        PBFTRoundStateCreateError<PartyID>
+    >
+    where PartiesErr: Display;
+    type State = PBFTProtoState<PartyID>;
+
+    fn rounds(
+        &self,
+        round_ids: RoundIDs,
+        parties: StaticParties<PartyID>,
+        self_party: Party,
+        party_data: &[Party]
+    ) -> Result<Self::Rounds, Self::RoundsError<StaticPartiesError>> {
+        SingleRound::create(
+            round_ids,
+            self.party_codec.clone(),
+            parties,
+            self_party,
+            party_data,
+            self.outbound_config.clone()
+        )
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -75,9 +75,6 @@ enum PBFTLeaderHint<Party> {
     This
 }
 
-// XXX the hint should be a separate type parameter, because it's not
-// necessary for round info, only for selecting leaders.
-
 /// Leader state.
 #[derive(Clone)]
 enum PBFTLeader<Party, Hint> {
@@ -1598,7 +1595,8 @@ where
         if let PBFTLeader::None { .. } = &self.leader {
             let mut best = self.highest_votes(votes)?;
 
-            // XXX this is a bad method; replace it with something better.
+            // ISSUE #4: this is a bad method; replace it with
+            // something better.
             if let PBFTLeader::None { hint } = &mut self.leader {
                 if best.len() > 1 {
                     let idx = random::<usize>() % best.len();
@@ -1832,7 +1830,8 @@ where
                 debug!(target: "pbft-proto-state",
                        "no one is the leader, generating view change");
 
-                // XXX this needs a better mechanism for picking a leader.
+                // ISSUE #4: this needs a better mechanism for picking
+                // a leader.
                 let parties: Vec<&CompoundHashID> =
                     self.party_hashes.values().collect();
                 let idx = (random::<usize>() % parties.len()) + 1;
@@ -3194,7 +3193,7 @@ fn test_empty_handle_prepare_lead_consistent_commit() {
     );
 }
 
-// XXX We should probably discard inconsistent commits.
+// ISSUE #5: We should probably discard inconsistent commits.
 
 #[test]
 fn test_withreq_handle_prepare_nolead_inconsistent_commit() {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1788,7 +1788,8 @@ where
                 debug!(target: "pbft-proto-state",
                        "we are the leader, not generating round");
 
-                // XXX This is temporary, for testing
+                // ISSUE #7: This is temporary, for testing.  The
+                // leader needs to generate a proposal here.
                 Ok(None)
             }
             // There is no leader, but we have a hint proposing ourself.

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,22219 @@
+// Copyright © 2024 The Johns Hopkins Applied Physics Laboratory LLC.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU Affero General Public License,
+// version 3, as published by the Free Software Foundation.  If you
+// would like to purchase a commercial license for this software, please
+// contact APL’s Tech Transfer at 240-592-0817 or
+// techtransfer@jhuapl.edu.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+//! Core protocol state implementations for the Castro-Liskov PBFT
+//! consensus protocol.
+use std::array::TryFromSliceError;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::fmt::Error;
+use std::fmt::Formatter;
+use std::hash::Hash;
+
+use bitvec::prelude::bitvec;
+use bitvec::prelude::BitVec;
+use constellation_common::codec::DatagramCodec;
+use constellation_common::hashid::CompoundHashAlgo;
+use constellation_common::hashid::CompoundHashID;
+use constellation_common::hashid::HashAlgo;
+use constellation_consensus_common::outbound::Outbound;
+use constellation_consensus_common::parties::Parties;
+use constellation_consensus_common::parties::PartyIDMap;
+use constellation_consensus_common::state::ProtoState;
+use constellation_consensus_common::state::ProtoStateCreate;
+use constellation_consensus_common::state::ProtoStateRound;
+use constellation_consensus_common::state::RoundState;
+use constellation_consensus_common::state::RoundStateUpdate;
+use log::debug;
+use log::error;
+use log::info;
+use log::trace;
+use log::warn;
+use rand::random;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::config::PBFTOutboundConfig;
+use crate::config::PBFTProtoStateConfig;
+use crate::generated::msgs::PbftContent;
+use crate::generated::msgs::PbftMsg;
+use crate::generated::msgs::PbftStateUpdate;
+use crate::generated::msgs::PbftUpdateAck;
+use crate::generated::req::PbftRequest;
+use crate::generated::req::PbftView;
+use crate::outbound::OutboundPartyIdx;
+use crate::outbound::PBFTOutbound;
+use crate::outbound::PBFTOutboundSend;
+
+const SELF_PARTY: usize = 0;
+
+/// Hints as to who to nominate for leader in a round.
+#[derive(Clone)]
+enum PBFTLeaderHint<Party> {
+    /// Make some other party the leader.
+    Other {
+        /// The party to make leader.
+        party: Party
+    },
+    /// Make ourselves the leader.
+    This
+}
+
+// XXX the hint should be a separate type parameter, because it's not
+// necessary for round info, only for selecting leaders.
+
+/// Leader state.
+#[derive(Clone)]
+enum PBFTLeader<Party, Hint> {
+    /// Someone else is the leader.
+    Other {
+        /// The current leader.
+        party: Party
+    },
+    /// We are the leader.
+    This,
+    /// No one is the leader.
+    None {
+        /// Hint as to who we should vote for.
+        hint: Hint
+    }
+}
+
+/// Inter-round state for the Castro-Liskov PBFT consensus protocol.
+pub struct PBFTProtoState<Party>
+where
+    Party: Clone + Display + Eq + Hash {
+    /// Configuration for creating [PBFTOutbound]s.
+    outbound_config: PBFTOutboundConfig,
+    /// Hash algorithm to use for parties
+    hash: CompoundHashAlgo,
+    /// Map from other parties to hashes.
+    party_hashes: HashMap<Party, CompoundHashID>,
+    /// Map from hashes to other parties.
+    hash_parties: HashMap<CompoundHashID, Party>,
+    /// Current leader.
+    leader: PBFTLeader<Party, Option<PBFTLeaderHint<Party>>>,
+    /// Hash for this party.
+    self_hash: CompoundHashID
+}
+
+/// PBFT state for the "prepare" phase.
+pub struct PrepareState<Req: Clone + Display + Eq + Hash> {
+    /// Number of parties.
+    nparties: usize,
+    /// Quorum size.
+    quorum: usize,
+    /// The value for which we sent a prepare.
+    prepared: Option<Req>,
+    /// Prepare vote counts for each value.
+    prepare_votes: HashMap<Req, BitVec>,
+    /// Which parties have voted.
+    prepare_voted: BitVec,
+    /// Number of prepare votes remaining.
+    prepare_remaining: usize,
+    /// Number of prepare votes held by current leader.
+    prepare_lead: usize,
+    /// Commit vote counts for each value captured in the prepare
+    /// phase.
+    commit_votes: HashMap<Req, BitVec>,
+    /// Bitmask of which parties have reported either completed or failed.
+    ///
+    /// This will cause the normal consistency checks on incoming
+    /// votes to be omitted.
+    completed: BitVec,
+    /// Bitmask of which parties have voted to commit.
+    commit_voted: BitVec,
+    /// Number of commit votes remaining.
+    commit_remaining: usize,
+    /// Number of commit votes held by current leader.
+    commit_lead: usize
+}
+
+/// PBFT state for the "commit" state.
+pub struct CommitState<Req: Clone + Display + Eq + Hash> {
+    /// Number of parties.
+    nparties: usize,
+    /// The value for which we sent a commit.
+    commit: Option<Req>,
+    /// Quorum size.
+    quorum: usize,
+    /// Bitmask of which parties have reported either completed or failed.
+    ///
+    /// This will cause the normal consistency checks on incoming
+    /// votes to be omitted.
+    completed: BitVec,
+    /// Commit vote counts for each value.
+    commit_votes: HashMap<Req, BitVec>,
+    /// Bitmask of which parties have voted to commit.
+    commit_voted: BitVec,
+    /// Number of commit votes remaining.
+    commit_remaining: usize,
+    /// Number of commit votes held by current leader.
+    commit_lead: usize
+}
+
+/// Information passed from the inter-round PBFT state to each round.
+pub struct PBFTRoundInfo<Party> {
+    leader: PBFTLeader<Party, ()>
+}
+
+/// Per-round state machine for the Castro-Liskov PBFT consensus
+/// protocol.
+pub enum PBFTRoundState<Req: Clone + Display + Eq + Hash> {
+    Prepare { prepare: PrepareState<Req> },
+    Commit { commit: CommitState<Req> }
+}
+
+/// Round result for [PBFTRoundState].
+pub enum PBFTRoundResult<Req> {
+    Complete { req: Req },
+    Fail { fail: PBFTVoteCounts<Req> }
+}
+
+/// Vote counts from a failed PBFT round.
+pub struct PBFTVoteCounts<Req> {
+    prepare: Option<Vec<(Req, usize)>>,
+    commit: Vec<(Req, usize)>
+}
+
+/// Errors that can occur creating a [PBFTRoundState].
+pub enum PBFTRoundStateCreateError<Party> {
+    BadParty { party: Party },
+    BadHint { party: Party }
+}
+
+/// Errors that can occur creating a [PBFTProtoState].
+pub enum PBFTProtoStateCreateError<Parties, Encode> {
+    Parties { err: Parties },
+    Encode { err: Encode }
+}
+
+/// Errors that can occur updating a [PBFTProtoState].
+pub enum PBFTProtoStateUpdateError {
+    BadParty { id: CompoundHashID },
+    BadSize { err: TryFromSliceError }
+}
+
+impl<Req> CommitState<Req>
+where
+    Req: Clone + Display + Eq + Hash
+{
+    /// Record a commit vote by a given party.
+    ///
+    /// This will not automatically record a prepare vote as well.
+    ///
+    /// This expects to only ever be called once for a given party.
+    ///
+    /// Returns whether the given vote won the commit vote.
+    fn record_commit_votes<Round>(
+        &mut self,
+        round: &Round,
+        lead_party: Option<usize>,
+        self_party: usize,
+        party: usize,
+        request: &Req
+    ) -> bool
+    where
+        Round: Display {
+        if self_party != party {
+            match self.commit_votes.entry(request.clone()) {
+                // Entry already exists.
+                Entry::Occupied(mut ent) => {
+                    let votes = ent.get_mut();
+
+                    // Add our own vote if we haven't voted already.
+                    let is_lead_or_view =
+                        lead_party.map_or(true, |lead| lead == party);
+
+                    if is_lead_or_view && self.commit.is_none() {
+                        votes.set(self_party, true);
+                        self.commit_remaining -= 1;
+                        self.commit_voted.set(self_party, true);
+                        self.commit_lead =
+                            self.commit_lead.max(votes.count_ones());
+                        self.commit = Some(request.clone());
+
+                        debug!(target: "pbft",
+                               "self-vote recorded, {} remaining, lead has {}",
+                               self.commit_remaining, self.commit_lead);
+                    }
+
+                    // Record party's vote.
+                    if !votes[party] {
+                        votes.set(party, true);
+                        self.commit_voted.set(party, true);
+                        self.commit_remaining -= 1;
+                        self.commit_lead =
+                            self.commit_lead.max(votes.count_ones());
+
+                        debug!(target: "pbft",
+                               concat!("commit vote recorded, {} remaining, ",
+                                       "lead has {}"),
+                               self.commit_remaining, self.commit_lead);
+
+                        votes.count_ones() >= self.quorum
+                    } else {
+                        // Something went wrong if we get here.
+
+                        error!(target: "pbft",
+                               concat!("commit votes for {} for round {} ",
+                                       "should not contain {}"),
+                               request, round, party);
+
+                        false
+                    }
+                }
+                // No entry yet; create one.
+                Entry::Vacant(ent) => {
+                    let votes = ent.insert(bitvec![0; self.nparties]);
+
+                    // Add our own vote if we haven't voted already.
+                    let is_lead_or_view =
+                        lead_party.map_or(true, |lead| lead == party);
+
+                    if is_lead_or_view && self.commit.is_none() {
+                        votes.set(self_party, true);
+                        self.commit_remaining -= 1;
+                        self.commit_voted.set(self_party, true);
+                        self.commit_lead =
+                            self.commit_lead.max(votes.count_ones());
+                        self.commit = Some(request.clone());
+
+                        debug!(target: "pbft",
+                               "self-vote recorded, {} remaining, lead has {}",
+                               self.commit_remaining, self.commit_lead);
+                    }
+
+                    // Record party's vote.
+                    votes.set(party, true);
+                    self.commit_voted.set(party, true);
+                    self.commit_remaining -= 1;
+                    self.commit_lead = self.commit_lead.max(votes.count_ones());
+
+                    votes.count_ones() >= self.quorum
+                }
+            }
+        } else {
+            // If we get here, it's a recoverable error.
+
+            error!(target: "pbft",
+                   "attempt to record self-vote for {} for round {}",
+                   request, round);
+
+            false
+        }
+    }
+
+    #[inline]
+    fn has_failed(&self) -> bool {
+        if self.commit_lead < self.quorum &&
+            (self.quorum - self.commit_lead > self.commit_remaining)
+        {
+            debug!(target: "pbft",
+                   concat!("lead commit candidate ({} votes) cannot ",
+                           "reach quorum of {} with only {} ",
+                           "votes remaining"),
+                   self.commit_lead, self.quorum, self.commit_remaining);
+
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Get the vote counts for this round.
+    fn fail(self) -> PBFTVoteCounts<Req> {
+        let commit = self
+            .commit_votes
+            .into_iter()
+            .map(|(req, bits)| (req, bits.count_ones()))
+            .collect();
+
+        PBFTVoteCounts {
+            commit: commit,
+            prepare: None
+        }
+    }
+
+    fn handle_fail<Round, Out>(
+        mut self,
+        out: &mut Out,
+        round: &Round,
+        party: usize
+    ) -> RoundStateUpdate<PBFTRoundState<Req>, PBFTRoundResult<Req>>
+    where
+        Out: PBFTOutboundSend<Req>,
+        Round: Display {
+        if !self.commit_voted[party] {
+            debug!(target: "pbft",
+                   "received fail from {} for round {}",
+                   party, round);
+            trace!(target: "pbft",
+                   "logging fail for commit from {} for round {}",
+                   party, round);
+
+            self.completed.set(party, true);
+
+            // Record the party as having voted and reduce the
+            // remaining count, but don't cast any votes.
+            self.commit_voted.set(party, true);
+            self.commit_remaining -= 1;
+
+            debug!(target: "pbft",
+                   "fail vote recorded, {} remaining, lead has {}",
+                   self.commit_remaining, self.commit_lead);
+
+            if self.has_failed() {
+                // The fail vote caused the round to fail.
+                info!(target: "pbft",
+                      "round failed due to failure votes by other parties");
+
+                out.send_fail();
+
+                // Transition to fail state.
+                RoundStateUpdate::Resolved {
+                    resolved: PBFTRoundResult::Fail { fail: self.fail() }
+                }
+            } else {
+                // The round is still live.
+                RoundStateUpdate::Pending {
+                    pending: PBFTRoundState::Commit { commit: self }
+                }
+            }
+        } else {
+            trace!(target: "pbft",
+                   concat!("received fail vote by {} in round {}, ",
+                           "but vote was already recorded"),
+                   party, round);
+
+            RoundStateUpdate::Pending {
+                pending: PBFTRoundState::Commit { commit: self }
+            }
+        }
+    }
+
+    /// Handle a `Commit` message.
+    fn handle_commit<Round, Out>(
+        self,
+        out: &mut Out,
+        round: &Round,
+        lead_party: Option<usize>,
+        party: usize,
+        request: Req
+    ) -> RoundStateUpdate<PBFTRoundState<Req>, PBFTRoundResult<Req>>
+    where
+        Out: PBFTOutboundSend<Req>,
+        Round: Display {
+        self.handle_commit_complete(
+            out, round, lead_party, party, request, false
+        )
+    }
+
+    /// Handle a `Complete` message.
+    fn handle_complete<Round, Out>(
+        self,
+        out: &mut Out,
+        round: &Round,
+        lead_party: Option<usize>,
+        party: usize,
+        request: Req
+    ) -> RoundStateUpdate<PBFTRoundState<Req>, PBFTRoundResult<Req>>
+    where
+        Out: PBFTOutboundSend<Req>,
+        Round: Display {
+        self.handle_commit_complete(
+            out, round, lead_party, party, request, true
+        )
+    }
+
+    /// Handle a `Commit` message.
+    fn handle_commit_complete<Round, Out>(
+        mut self,
+        out: &mut Out,
+        round: &Round,
+        lead_party: Option<usize>,
+        party: usize,
+        request: Req,
+        complete: bool
+    ) -> RoundStateUpdate<PBFTRoundState<Req>, PBFTRoundResult<Req>>
+    where
+        Out: PBFTOutboundSend<Req>,
+        Round: Display {
+        if self.commit_voted[party] {
+            match self.commit_votes.get(&request) {
+                Some(votes) => {
+                    if votes[party] {
+                        // This is ok, just a redundant message.
+
+                        trace!(target: "pbft",
+                               concat!("received redundant commit ",
+                                       "vote ({}) by {} in round {}"),
+                               request, party, round)
+                    } else if !self.completed[party] && !complete {
+                        // Something's wrong: the party is listed as
+                        // voting, but not for this value.
+                        //
+                        // We omit this check if a party is marked as
+                        // having reported completion or failure, as
+                        // this can contradict their vote.
+
+                        warn!(target: "pbft",
+                      concat!("party {} sent commit vote ",
+                              "({}) for round {}, is listed ",
+                              "as voting, but not present in ",
+                              "votes for proposal"),
+                      party, request, round);
+                    }
+                }
+                None if !self.completed[party] && !complete => {
+                    // The party is listed as having voted, but no
+                    // record exists for this proposal for this round.
+                    //
+                    // We omit this check if a party is marked as
+                    // having reported completion or failure, as this
+                    // can contradict their vote.
+
+                    warn!(target: "pbft",
+                      concat!("party {} sent commit vote ",
+                              "({}) for round {}, is listed ",
+                              "as voting, but no votes exist ",
+                              "for proposal"),
+                      party, request, round);
+                }
+                _ => {}
+            }
+
+            RoundStateUpdate::Pending {
+                pending: PBFTRoundState::Commit { commit: self }
+            }
+        } else {
+            // This party has not yet voted to commit; we're good.
+            if complete {
+                debug!(target: "pbft",
+                   "received complete ({}) from {} for round {}",
+                   request, party, round);
+
+                self.completed.set(party, true);
+            } else {
+                debug!(target: "pbft",
+                   "received commit ({}) from {} for round {}",
+                   request, party, round);
+            }
+
+            if !self.commit_voted[party] {
+                trace!(target: "pbft",
+                   "logging commit vote for {} from {} for round {}",
+                   request, party, round);
+
+                let commit_was_empty = self.commit.is_none();
+
+                // Log the commit vote.
+                if self.record_commit_votes(
+                    round, lead_party, SELF_PARTY, party, &request
+                ) {
+                    info!(target: "pbft",
+                      "proposal {} has won commit vote for round {}",
+                      request, round);
+
+                    // Send complete messages.
+                    out.send_complete(&request);
+
+                    // Transition into complete state.
+                    RoundStateUpdate::Resolved {
+                        resolved: PBFTRoundResult::Complete { req: request }
+                    }
+                } else if self.has_failed() {
+                    info!(target: "pbft",
+                      "round failed in commit phase");
+
+                    out.send_fail();
+
+                    // Transition to fail state
+                    RoundStateUpdate::Resolved {
+                        resolved: PBFTRoundResult::Fail { fail: self.fail() }
+                    }
+                } else {
+                    if commit_was_empty {
+                        if let Some(commit) = &self.commit {
+                            out.send_commit(commit);
+                        }
+                    }
+
+                    RoundStateUpdate::Pending {
+                        pending: PBFTRoundState::Commit { commit: self }
+                    }
+                }
+            } else {
+                RoundStateUpdate::Pending {
+                    pending: PBFTRoundState::Commit { commit: self }
+                }
+            }
+        }
+    }
+}
+
+impl<Req> PrepareState<Req>
+where
+    Req: Clone + Display + Eq + Hash
+{
+    /// Create a new `PrepareState` for a non-leader node.
+    fn new(nparties: usize) -> Self {
+        let nfaults = (nparties - 1) / 3;
+        let quorum = nparties - nfaults;
+
+        PrepareState {
+            quorum: quorum,
+            nparties: nparties,
+            prepared: None,
+            prepare_votes: HashMap::with_capacity(2),
+            prepare_voted: bitvec![0; nparties],
+            prepare_remaining: nparties,
+            prepare_lead: 0,
+            commit_votes: HashMap::with_capacity(2),
+            commit_voted: bitvec![0; nparties],
+            completed: bitvec![0; nparties],
+            commit_remaining: nparties,
+            commit_lead: 0
+        }
+    }
+
+    /// Create a new `PBFTRoundState` for a leader.
+    fn with_req(
+        nparties: usize,
+        request: Req
+    ) -> Self {
+        let mut out = Self::new(nparties);
+
+        // Record our own vote.
+        let mut votes = bitvec![0; out.nparties];
+
+        votes.set(0, true);
+        out.prepare_votes.insert(request.clone(), votes);
+        out.prepare_voted.set(0, true);
+        out.prepare_remaining -= 1;
+        out.prepare_lead = 1;
+        out.prepared = Some(request);
+
+        out
+    }
+
+    /// Convert this into a [CommitState].
+    #[inline]
+    fn into_commit(self) -> CommitState<Req> {
+        CommitState {
+            nparties: self.nparties,
+            quorum: self.quorum,
+            completed: self.completed,
+            commit: self.prepared,
+            commit_remaining: self.commit_remaining,
+            commit_votes: self.commit_votes,
+            commit_voted: self.commit_voted,
+            commit_lead: self.commit_lead
+        }
+    }
+
+    /// Record a commit vote by a given party.
+    ///
+    /// This will not automatically record a prepare vote as well.
+    ///
+    /// This expects to only ever be called once for a given party.
+    ///
+    /// Returns whether the given vote won the commit vote.
+    fn record_commit_votes<Round>(
+        &mut self,
+        round: &Round,
+        self_party: usize,
+        party: usize,
+        request: &Req
+    ) -> bool
+    where
+        Round: Display {
+        if self_party != party {
+            match self.commit_votes.entry(request.clone()) {
+                // Entry already exists.
+                Entry::Occupied(mut ent) => {
+                    let votes = ent.get_mut();
+
+                    if !votes[party] {
+                        votes.set(party, true);
+                        self.commit_voted.set(party, true);
+                        self.commit_remaining -= 1;
+                        self.commit_lead =
+                            self.commit_lead.max(votes.count_ones());
+
+                        debug!(target: "pbft",
+                               concat!("commit vote recorded, {} remaining, ",
+                                       "lead has {}"),
+                               self.commit_remaining, self.commit_lead);
+
+                        votes.count_ones() >= self.quorum
+                    } else {
+                        // Something went wrong if we get here.
+
+                        error!(target: "pbft",
+                               concat!("commit votes for {} for round {} ",
+                                       "should not contain {}"),
+                               request, round, party);
+
+                        false
+                    }
+                }
+                // No entry yet; create one.
+                Entry::Vacant(ent) => {
+                    let votes = ent.insert(bitvec![0; self.nparties]);
+
+                    votes.set(party, true);
+                    self.commit_voted.set(party, true);
+                    self.commit_remaining -= 1;
+                    self.commit_lead = self.commit_lead.max(votes.count_ones());
+
+                    votes.count_ones() >= self.quorum
+                }
+            }
+        } else {
+            // If we get here, it's a recoverable error.
+
+            error!(target: "pbft",
+                   "attempt to record self-vote for {} for round {}",
+                   request, round);
+
+            false
+        }
+    }
+
+    fn record_self_commit<Round>(
+        &mut self,
+        round: &Round,
+        self_party: usize
+    ) -> bool
+    where
+        Round: Display {
+        if let Some(request) = &self.prepared {
+            match self.commit_votes.entry(request.clone()) {
+                // Entry already exists.
+                Entry::Occupied(mut ent) => {
+                    let votes = ent.get_mut();
+
+                    if !votes[self_party] {
+                        votes.set(self_party, true);
+                        self.commit_voted.set(self_party, true);
+                        self.commit_remaining -= 1;
+                        self.commit_lead =
+                            self.commit_lead.max(votes.count_ones());
+                    } else {
+                        error!(target: "pbft",
+                               concat!("commit self-vote already recorded ",
+                                       "for {} in round {}"),
+                               request, round)
+                    }
+
+                    votes.count_ones() >= self.quorum
+                }
+                // No entry yet; create one.
+                Entry::Vacant(ent) => {
+                    let votes = ent.insert(bitvec![0; self.nparties]);
+
+                    votes.set(self_party, true);
+                    self.commit_voted.set(self_party, true);
+                    self.commit_remaining -= 1;
+                    self.commit_lead = self.commit_lead.max(votes.count_ones());
+
+                    votes.count_ones() >= self.quorum
+                }
+            }
+        } else {
+            false
+        }
+    }
+
+    /// Record a prepare vote by a given party.
+    ///
+    /// This will also cause us to issue a prepare vote, if we haven't
+    /// already.
+    ///
+    /// This expects to only ever be called once for a given party.
+    ///
+    /// Returns whether the given vote won the prepare vote.
+    fn record_prepare_votes<Round>(
+        &mut self,
+        round: &Round,
+        lead_party: Option<usize>,
+        self_party: usize,
+        party: usize,
+        request: &Req
+    ) -> bool
+    where
+        Round: Display {
+        if self_party != party {
+            match self.prepare_votes.entry(request.clone()) {
+                // Entry already exists.
+                Entry::Occupied(mut ent) => {
+                    let votes = ent.get_mut();
+
+                    // Add our own vote if we haven't voted already.
+                    let is_lead_or_view =
+                        lead_party.map_or(true, |lead| lead == party);
+
+                    if is_lead_or_view && self.prepared.is_none() {
+                        votes.set(self_party, true);
+                        self.prepare_remaining -= 1;
+                        self.prepare_voted.set(self_party, true);
+                        self.prepare_lead =
+                            self.prepare_lead.max(votes.count_ones());
+                        self.prepared = Some(request.clone());
+
+                        debug!(target: "pbft",
+                               "self-vote recorded, {} remaining, lead has {}",
+                               self.prepare_remaining, self.prepare_lead);
+                    }
+
+                    // Record party's vote
+                    votes.set(party, true);
+                    self.prepare_voted.set(party, true);
+                    self.prepare_remaining -= 1;
+                    self.prepare_lead =
+                        self.prepare_lead.max(votes.count_ones());
+
+                    debug!(target: "pbft",
+                           "prepare vote recorded, {} remaining, lead has {}",
+                           self.prepare_remaining, self.prepare_lead);
+
+                    votes.count_ones() >= self.quorum
+                }
+                // No entry yet; create one.
+                Entry::Vacant(ent) => {
+                    let votes = ent.insert(bitvec![0; self.nparties]);
+
+                    // Add our own vote if we haven't voted already.
+                    let is_lead_or_view =
+                        lead_party.map_or(true, |lead| lead == party);
+
+                    if is_lead_or_view && self.prepared.is_none() {
+                        votes.set(self_party, true);
+                        self.prepare_remaining -= 1;
+                        self.prepare_voted.set(self_party, true);
+                        self.prepare_lead =
+                            self.prepare_lead.max(votes.count_ones());
+                        self.prepared = Some(request.clone());
+
+                        debug!(target: "pbft",
+                               "self-vote recorded, {} remaining, lead has {}",
+                               self.prepare_remaining, self.prepare_lead);
+                    }
+
+                    // Record party's vote
+                    votes.set(party, true);
+                    self.prepare_voted.set(party, true);
+                    self.prepare_remaining -= 1;
+                    self.prepare_lead =
+                        self.prepare_lead.max(votes.count_ones());
+
+                    debug!(target: "pbft",
+                           "prepare vote recorded, {} remaining, lead has {}",
+                           self.prepare_remaining, self.prepare_lead);
+
+                    votes.count_ones() >= self.quorum
+                }
+            }
+        } else {
+            // If we get here, it's a recoverable error.
+
+            error!(target: "pbft",
+                   "attempt to record self-vote for {} for round {}",
+                   request, round);
+
+            false
+        }
+    }
+
+    #[inline]
+    fn has_failed(&self) -> bool {
+        if self.prepare_lead < self.quorum &&
+            (self.quorum - self.prepare_lead > self.prepare_remaining)
+        {
+            debug!(target: "pbft",
+                   concat!("lead prepare candidate ({} votes) cannot ",
+                           "reach quorum of {} with only {} ",
+                           "votes remaining"),
+                   self.prepare_lead, self.quorum, self.prepare_remaining);
+
+            true
+        } else if self.commit_lead < self.quorum &&
+            (self.quorum - self.commit_lead > self.commit_remaining)
+        {
+            debug!(target: "pbft",
+                   concat!("lead commit candidate ({} votes) cannot ",
+                           "reach quorum of {} with only {} ",
+                           "votes remaining"),
+                   self.commit_lead, self.quorum, self.commit_remaining);
+
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Get the vote counts for this round.
+    fn fail(self) -> PBFTVoteCounts<Req> {
+        let commit = self
+            .commit_votes
+            .into_iter()
+            .map(|(req, bits)| (req, bits.count_ones()))
+            .collect();
+        let prepare = self
+            .prepare_votes
+            .into_iter()
+            .map(|(req, bits)| (req, bits.count_ones()))
+            .collect();
+
+        PBFTVoteCounts {
+            prepare: Some(prepare),
+            commit: commit
+        }
+    }
+
+    fn handle_fail<Round, Out>(
+        mut self,
+        out: &mut Out,
+        round: &Round,
+        party: usize
+    ) -> RoundStateUpdate<PBFTRoundState<Req>, PBFTRoundResult<Req>>
+    where
+        Out: PBFTOutboundSend<Req>,
+        Round: Display {
+        if !self.commit_voted[party] || !self.prepare_voted[party] {
+            debug!(target: "pbft",
+               "received fail from {} for round {}",
+               party, round);
+
+            self.completed.set(party, true);
+
+            if !self.prepare_voted[party] {
+                // Record the party as having voted and reduce the
+                // remaining count, but don't cast any votes.
+                trace!(target: "pbft",
+                   "logging fail for prepare from {} for round {}",
+                   party, round);
+
+                self.prepare_voted.set(party, true);
+                self.prepare_remaining -= 1;
+            }
+
+            if !self.commit_voted[party] {
+                // Record the party as having voted and reduce the
+                // remaining count, but don't cast any votes.
+                trace!(target: "pbft",
+                   "logging fail for commit from {} for round {}",
+                   party, round);
+
+                self.commit_voted.set(party, true);
+                self.commit_remaining -= 1;
+
+                debug!(target: "pbft",
+                   "fail vote recorded, {} remaining, lead has {}",
+                   self.prepare_remaining, self.prepare_lead);
+            }
+
+            if self.has_failed() {
+                // The fail vote caused the round to fail.
+                info!(target: "pbft",
+                  "round failed due to failure votes by other parties");
+
+                out.send_fail();
+
+                // Transition to fail state.
+                RoundStateUpdate::Resolved {
+                    resolved: PBFTRoundResult::Fail { fail: self.fail() }
+                }
+            } else {
+                // The round is still live.
+
+                RoundStateUpdate::Pending {
+                    pending: PBFTRoundState::Prepare { prepare: self }
+                }
+            }
+        } else {
+            trace!(target: "pbft",
+               concat!("received fail vote by {} in round {}, ",
+                       "but vote was already recorded"),
+               party, round);
+
+            RoundStateUpdate::Pending {
+                pending: PBFTRoundState::Prepare { prepare: self }
+            }
+        }
+    }
+
+    /// Handle a `Prepare` message.
+    fn handle_prepare<Round, Out>(
+        mut self,
+        out: &mut Out,
+        round: &Round,
+        lead_party: Option<usize>,
+        party: usize,
+        request: Req
+    ) -> RoundStateUpdate<PBFTRoundState<Req>, PBFTRoundResult<Req>>
+    where
+        Out: PBFTOutboundSend<Req>,
+        Round: Display {
+        if self.prepare_voted[party] {
+            match self.prepare_votes.get(&request) {
+                Some(votes) => {
+                    if votes[party] {
+                        // This is ok, just a redundant message.
+
+                        trace!(target: "pbft",
+                       concat!("received redundant prepare ",
+                               "vote ({}) by {} in round {}"),
+                       request, party, round)
+                    } else if !self.completed[party] {
+                        // Something's wrong: the party is listed as
+                        // voting, but not for this value.
+                        //
+                        // We omit this check if a party is marked as
+                        // having reported completion or failure, as
+                        // this can contradict their vote.
+
+                        warn!(target: "pbft",
+                      concat!("party {} sent prepare vote ",
+                              "({}) for round {}, is listed ",
+                              "as voting, but not present in ",
+                              "votes for proposal"),
+                      party, request, round);
+                    }
+                }
+                None if !self.completed[party] => {
+                    // The party is listed as having voted, but no
+                    // record exists for this proposal for this round.
+                    //
+                    // We omit this check if a party is marked as
+                    // having reported completion or failure, as this
+                    // can contradict their vote.
+
+                    warn!(target: "pbft",
+                      concat!("party {} sent prepare vote ",
+                              "({}) for round {}, is listed ",
+                              "as voting, but no votes exist ",
+                              "for proposal"),
+                      party, request, round);
+                }
+                _ => {}
+            }
+
+            RoundStateUpdate::Pending {
+                pending: PBFTRoundState::Prepare { prepare: self }
+            }
+        } else {
+            // This party has not yet voted to prepare; we're good.
+            debug!(target: "pbft",
+               "received prepare ({}) from {} for round {}",
+               request, party, round);
+            trace!(target: "pbft",
+               "logging prepare vote for {} from {} for round {}",
+               request, party, round);
+
+            let prepared_was_empty = self.prepared.is_none();
+
+            // Record the prepare vote.
+            if self.record_prepare_votes(
+                round, lead_party, SELF_PARTY, party, &request
+            ) {
+                // The request has won the prepare vote.
+                info!(target: "pbft",
+                  "{} won prepare vote for round {}",
+                  request, round);
+                trace!(target: "pbft",
+                   "logging our commit vote for {} for round {}",
+                   request, round);
+
+                // Record our commit vote.
+                if self.record_self_commit(round, SELF_PARTY) {
+                    // Our commit vote caused the request to win the
+                    // round.  Go straight to complete.
+                    info!(target: "pbft",
+                      "{} won commit vote for round {}",
+                      request, round);
+
+                    // Send complete messages.
+                    out.send_complete(&request);
+
+                    RoundStateUpdate::Resolved {
+                        resolved: PBFTRoundResult::Complete { req: request }
+                    }
+                } else if self.has_failed() {
+                    info!(target: "pbft",
+                      "round failed in commit phase");
+
+                    out.send_fail();
+
+                    // Transition to fail state
+                    RoundStateUpdate::Resolved {
+                        resolved: PBFTRoundResult::Fail { fail: self.fail() }
+                    }
+                } else {
+                    // Begin the commit phase.
+                    debug!(target: "pbft",
+                       "entering commit phase for {} for round {}",
+                       request, round);
+
+                    if let Some(commit) = &self.prepared {
+                        out.send_commit(commit);
+                    }
+
+                    RoundStateUpdate::Pending {
+                        pending: PBFTRoundState::Commit {
+                            commit: self.into_commit()
+                        }
+                    }
+                }
+            } else if self.has_failed() {
+                info!(target: "pbft",
+                  "round failed in prepare phase");
+
+                out.send_fail();
+
+                // Transition to fail state
+                RoundStateUpdate::Resolved {
+                    resolved: PBFTRoundResult::Fail { fail: self.fail() }
+                }
+            } else {
+                if let Some(request) = &self.prepared {
+                    if prepared_was_empty {
+                        out.send_prepare(request);
+                    }
+                }
+
+                // Not enough votes to decide the round.
+                RoundStateUpdate::Pending {
+                    pending: PBFTRoundState::Prepare { prepare: self }
+                }
+            }
+        }
+    }
+
+    /// Handle a `Commit` message.
+    fn handle_commit<Round, Out>(
+        self,
+        out: &mut Out,
+        round: &Round,
+        lead_party: Option<usize>,
+        party: usize,
+        request: Req
+    ) -> RoundStateUpdate<PBFTRoundState<Req>, PBFTRoundResult<Req>>
+    where
+        Out: PBFTOutboundSend<Req>,
+        Round: Display {
+        self.handle_commit_complete(
+            out, round, lead_party, party, request, false
+        )
+    }
+
+    /// Handle a `Complete` message.
+    fn handle_complete<Round, Out>(
+        self,
+        out: &mut Out,
+        round: &Round,
+        lead_party: Option<usize>,
+        party: usize,
+        request: Req
+    ) -> RoundStateUpdate<PBFTRoundState<Req>, PBFTRoundResult<Req>>
+    where
+        Out: PBFTOutboundSend<Req>,
+        Round: Display {
+        self.handle_commit_complete(
+            out, round, lead_party, party, request, true
+        )
+    }
+
+    /// Utility function for handling both commit and complete.
+    fn handle_commit_complete<Round, Out>(
+        mut self,
+        out: &mut Out,
+        round: &Round,
+        lead_party: Option<usize>,
+        party: usize,
+        request: Req,
+        complete: bool
+    ) -> RoundStateUpdate<PBFTRoundState<Req>, PBFTRoundResult<Req>>
+    where
+        Out: PBFTOutboundSend<Req>,
+        Round: Display {
+        if self.commit_voted[party] {
+            match self.prepare_votes.get(&request) {
+                Some(votes) => {
+                    if votes[party] {
+                        // This is ok, just a redundant message.
+
+                        trace!(target: "pbft",
+                       concat!("received redundant commit ",
+                               "vote ({}) by {} in round {}"),
+                       request, party, round)
+                    } else if !self.completed[party] && !complete {
+                        // Something's wrong: the party is listed as
+                        // voting, but not for this value.
+                        //
+                        // We omit this check if a party is marked as
+                        // having reported completion or failure, as
+                        // this can contradict their vote.
+
+                        warn!(target: "pbft",
+                      concat!("party {} sent commit vote ",
+                              "({}) for round {}, is listed ",
+                              "as voting, but not present in ",
+                              "votes for proposal"),
+                      party, request, round);
+                    }
+                }
+                None if !self.completed[party] && !complete => {
+                    // The party is listed as having voted, but no
+                    // record exists for this proposal for this round.
+                    //
+                    // We omit this check if a party is marked as
+                    // having reported completion or failure, as this
+                    // can contradict their vote.
+
+                    warn!(target: "pbft",
+                      concat!("party {} sent commit vote ",
+                              "({}) for round {}, is listed ",
+                              "as voting, but no votes exist ",
+                              "for proposal"),
+                      party, request, round);
+                }
+                _ => {}
+            }
+
+            RoundStateUpdate::Pending {
+                pending: PBFTRoundState::Prepare { prepare: self }
+            }
+        } else {
+            // This party has not yet voted to commit; we're good.
+            if complete {
+                debug!(target: "pbft",
+                   "received complete ({}) from {} for round {}",
+                   request, party, round);
+
+                self.completed.set(party, true);
+            } else {
+                debug!(target: "pbft",
+                   "received commit ({}) from {} for round {}",
+                   request, party, round);
+            }
+
+            // First, see if we need to record a prepare vote
+            if !self.prepare_voted[party] {
+                // We need to record a prepare vote.
+                trace!(target: "pbft",
+                   "logging prepare vote for {} from {} for round {}",
+                   request, party, round);
+
+                let is_lead_or_view =
+                    lead_party.map_or(true, |lead| lead == party);
+
+                if is_lead_or_view && self.prepared.is_none() {
+                    out.send_prepare(&request);
+                }
+
+                // Record the prepare vote.
+                if self.record_prepare_votes(
+                    round, lead_party, SELF_PARTY, party, &request
+                ) {
+                    // The request has won the prepare vote.
+                    info!(target: "pbft",
+                      "{} won prepare vote for round {}",
+                      request, round);
+                    trace!(target: "pbft",
+                       "logging our commit vote for {} for round {}",
+                       request, round);
+
+                    // Record our commit vote.
+                    if self.record_self_commit(round, SELF_PARTY) {
+                        // Our commit vote caused the request to win
+                        // the round.  Go straight to complete.
+                        info!(target: "pbft",
+                          "{} won commit vote for round {}",
+                          request, round);
+
+                        // Send complete messages.
+                        out.send_complete(&request);
+
+                        return RoundStateUpdate::Resolved {
+                            resolved: PBFTRoundResult::Complete {
+                                req: request
+                            }
+                        };
+                    } else if self.has_failed() {
+                        info!(target: "pbft",
+                          "round failed in commit phase");
+
+                        out.send_fail();
+
+                        // Transition to fail state
+                        return RoundStateUpdate::Resolved {
+                            resolved: PBFTRoundResult::Fail {
+                                fail: self.fail()
+                            }
+                        };
+                    } else {
+                        // Begin the commit phase.
+                        debug!(target: "pbft",
+                           "entering commit phase for {} for round {}",
+                           request, round);
+
+                        // Transition to the commit state and handle
+                        // the commit vote there.
+                        let commit = self.into_commit();
+
+                        return commit.handle_commit_complete(
+                            out, round, lead_party, party, request, complete
+                        );
+                    }
+                } else if self.has_failed() {
+                    info!(target: "pbft",
+                      "round failed in prepare phase");
+
+                    out.send_fail();
+
+                    // Transition to fail state
+                    return RoundStateUpdate::Resolved {
+                        resolved: PBFTRoundResult::Fail { fail: self.fail() }
+                    };
+                }
+            }
+
+            if !self.commit_voted[party] {
+                trace!(target: "pbft",
+                   "logging commit vote for {} from {} for round {}",
+                   request, party, round);
+
+                // Now, record the actual commit vote.
+                if self.record_commit_votes(&round, SELF_PARTY, party, &request)
+                {
+                    // The request won the commit vote outright.
+                    info!(target: "pbft",
+                      concat!("proposal {} has won commit ",
+                              "vote for round {}"),
+                      request, round);
+
+                    // Still request to send commit messages,
+                    // for the sake of the other parties.
+                    out.send_complete(&request);
+
+                    // Transition into complete state.
+                    RoundStateUpdate::Resolved {
+                        resolved: PBFTRoundResult::Complete { req: request }
+                    }
+                } else if self.has_failed() {
+                    // The commit vote is deadlocked.
+                    info!(target: "pbft",
+                      "round failed in prepare phase");
+
+                    out.send_fail();
+
+                    // Transition to fail state
+                    RoundStateUpdate::Resolved {
+                        resolved: PBFTRoundResult::Fail { fail: self.fail() }
+                    }
+                } else {
+                    // The round is still unresolved.
+
+                    RoundStateUpdate::Pending {
+                        pending: PBFTRoundState::Prepare { prepare: self }
+                    }
+                }
+            } else {
+                // The round is still unresolved.
+
+                RoundStateUpdate::Pending {
+                    pending: PBFTRoundState::Prepare { prepare: self }
+                }
+            }
+        }
+    }
+}
+
+impl<Req> PBFTRoundState<Req>
+where
+    Req: Clone + Display + Eq + Hash
+{
+    /// Create a new `PBFTRoundState` for a non-leader party.
+    #[inline]
+    fn new(nparties: usize) -> Self {
+        PBFTRoundState::Prepare {
+            prepare: PrepareState::new(nparties)
+        }
+    }
+
+    /// Create a new `PBFTRoundState` for a leader.
+    #[inline]
+    fn with_req<Out>(
+        out: &mut Out,
+        nparties: usize,
+        request: Req
+    ) -> Self
+    where
+        Out: PBFTOutboundSend<Req> {
+        // Send out prepare messages.
+        out.send_prepare(&request);
+
+        PBFTRoundState::Prepare {
+            prepare: PrepareState::with_req(nparties, request)
+        }
+    }
+
+    /// Handle a `Prepare` message.
+    fn prepare<Party, Round, Out>(
+        self,
+        out: &mut Out,
+        round: &Round,
+        lead_party: &PBFTLeader<Party, ()>,
+        party: &Party,
+        request: Req
+    ) -> RoundStateUpdate<Self, PBFTRoundResult<Req>>
+    where
+        Party: Clone + Display + From<usize> + Into<usize>,
+        Out: PBFTOutboundSend<Req>,
+        Round: Display {
+        let party: usize = party.clone().into() + 1;
+        let lead_party: Option<usize> = match lead_party {
+            PBFTLeader::Other { party } => Some(party.clone().into()),
+            PBFTLeader::This => Some(SELF_PARTY),
+            PBFTLeader::None { .. } => None
+        };
+
+        match self {
+            // This is the main body; everything else is a disregard case.
+            PBFTRoundState::Prepare { prepare: state } => {
+                state.handle_prepare(out, round, lead_party, party, request)
+            }
+            // Someone sent us a prepare when we're in the commit
+            // phase.  Disregard, but this could be just stale
+            // messages.
+            PBFTRoundState::Commit { commit: state } => {
+                debug!(target: "pbft",
+                       concat!("received prepare ({}) for round {} ",
+                               "from {} when already in commit phase"),
+                       request, round, party);
+
+                RoundStateUpdate::Pending {
+                    pending: PBFTRoundState::Commit { commit: state }
+                }
+            }
+        }
+    }
+
+    /// Handle a `Commit` message.
+    fn commit<Party, Round, Out>(
+        self,
+        out: &mut Out,
+        round: &Round,
+        lead_party: &PBFTLeader<Party, ()>,
+        party: &Party,
+        request: Req
+    ) -> RoundStateUpdate<Self, PBFTRoundResult<Req>>
+    where
+        Party: Clone + Display + From<usize> + Into<usize>,
+        Out: PBFTOutboundSend<Req>,
+        Round: Display {
+        let party: usize = party.clone().into() + 1;
+        let lead_party: Option<usize> = match lead_party {
+            PBFTLeader::Other { party } => Some(party.clone().into()),
+            PBFTLeader::This => Some(SELF_PARTY),
+            PBFTLeader::None { .. } => None
+        };
+
+        match self {
+            // We got a commit message in the prepare state; this is
+            // potentially valid.
+            PBFTRoundState::Prepare { prepare: state } => {
+                state.handle_commit(out, round, lead_party, party, request)
+            }
+            PBFTRoundState::Commit { commit: state } => {
+                state.handle_commit(out, round, lead_party, party, request)
+            }
+        }
+    }
+
+    /// Handle a `Complete` message.
+    fn complete<Party, Round, Out>(
+        self,
+        out: &mut Out,
+        round: &Round,
+        lead_party: &PBFTLeader<Party, ()>,
+        party: &Party,
+        request: Req
+    ) -> RoundStateUpdate<Self, PBFTRoundResult<Req>>
+    where
+        Party: Clone + Display + From<usize> + Into<usize>,
+        Out: PBFTOutboundSend<Req>,
+        Round: Display {
+        let party: usize = party.clone().into() + 1;
+        let lead_party: Option<usize> = match lead_party {
+            PBFTLeader::Other { party } => Some(party.clone().into()),
+            PBFTLeader::This => Some(SELF_PARTY),
+            PBFTLeader::None { .. } => None
+        };
+
+        match self {
+            // We got a commit message in the prepare state; this is
+            // potentially valid.
+            PBFTRoundState::Prepare { prepare: state } => {
+                state.handle_complete(out, round, lead_party, party, request)
+            }
+            PBFTRoundState::Commit { commit: state } => {
+                state.handle_complete(out, round, lead_party, party, request)
+            }
+        }
+    }
+
+    /// Handle a `Fail` message.
+    fn fail<Party, Round, Out>(
+        self,
+        out: &mut Out,
+        round: &Round,
+        party: &Party
+    ) -> RoundStateUpdate<Self, PBFTRoundResult<Req>>
+    where
+        Party: Clone + Display + From<usize> + Into<usize>,
+        Out: PBFTOutboundSend<Req>,
+        Round: Display {
+        let party: usize = party.clone().into() + 1;
+
+        match self {
+            // We got a commit message in the prepare state; this is
+            // potentially valid.
+            PBFTRoundState::Prepare { prepare: state } => {
+                state.handle_fail(out, round, party)
+            }
+            PBFTRoundState::Commit { commit: state } => {
+                state.handle_fail(out, round, party)
+            }
+        }
+    }
+}
+
+impl<Party> PBFTProtoState<Party>
+where
+    Party: Clone + Display + Eq + Hash
+{
+    #[inline]
+    fn nparties(&self) -> usize {
+        self.party_hashes.len() + 1
+    }
+
+    fn hash_to_party(
+        &self,
+        id: &[u8]
+    ) -> Result<PBFTLeaderHint<Party>, PBFTProtoStateUpdateError> {
+        let id = self
+            .hash
+            .wrap_hashed_bytes(id)
+            .map_err(|err| PBFTProtoStateUpdateError::BadSize { err: err })?;
+
+        if id == self.self_hash {
+            Ok(PBFTLeaderHint::This)
+        } else {
+            match self.hash_parties.get(&id) {
+                Some(party) => Ok(PBFTLeaderHint::Other {
+                    party: party.clone()
+                }),
+                None => Err(PBFTProtoStateUpdateError::BadParty { id: id })
+            }
+        }
+    }
+
+    fn highest_votes(
+        &self,
+        votes: PBFTVoteCounts<PbftRequest>
+    ) -> Result<Vec<PBFTLeaderHint<Party>>, PBFTProtoStateUpdateError> {
+        let size = votes.commit.len();
+        let size = votes
+            .prepare
+            .as_ref()
+            .map_or(size, |votes| size.max(votes.len()));
+        let mut max = 0;
+        let mut best = Vec::with_capacity(size);
+
+        // Run through the commit votes.
+        for (req, nvotes) in votes.commit.iter() {
+            // If it's a view change request, update the
+            // best votes.
+            if *nvotes >= max {
+                if let PbftRequest::View(PbftView { id }) = req {
+                    let party = self.hash_to_party(id)?;
+
+                    if *nvotes == max {
+                        best.clear()
+                    }
+
+                    max = *nvotes;
+                    best.push(party.clone())
+                }
+            }
+        }
+
+        // Run through the prepare votes if we have them.
+        if let Some(prepare_votes) = &votes.prepare {
+            for (req, nvotes) in prepare_votes.iter() {
+                // If it's a view change request, update the
+                // best votes.
+                if *nvotes >= max {
+                    if let PbftRequest::View(PbftView { id }) = req {
+                        let party = self.hash_to_party(id)?;
+
+                        if *nvotes == max {
+                            best.clear()
+                        }
+
+                        max = *nvotes;
+                        best.push(party.clone())
+                    }
+                }
+            }
+        }
+
+        Ok(best)
+    }
+
+    fn update_leader_hint(
+        &mut self,
+        votes: PBFTVoteCounts<PbftRequest>
+    ) -> Result<(), PBFTProtoStateUpdateError> {
+        // If there is no leader, update the hint.
+        if let PBFTLeader::None { .. } = &self.leader {
+            let mut best = self.highest_votes(votes)?;
+
+            // XXX this is a bad method; replace it with something better.
+            if let PBFTLeader::None { hint } = &mut self.leader {
+                if best.len() > 1 {
+                    let idx = random::<usize>() % best.len();
+
+                    *hint = Some(best[idx].clone());
+                } else {
+                    *hint = best.pop()
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<RoundID, PartyID, Party, Codec>
+    ProtoStateCreate<RoundID, PartyID, Party, Codec> for PBFTProtoState<PartyID>
+where
+    Party: Clone + for<'a> Deserialize<'a> + Display + Eq + Hash + Serialize,
+    PartyID: Clone + Display + Eq + Hash + Into<usize>,
+    Codec: DatagramCodec<Party>
+{
+    type Config = PBFTProtoStateConfig;
+    type CreateError<PartiesErr> =
+        PBFTProtoStateCreateError<PartiesErr, Codec::EncodeError>
+    where PartiesErr: Display;
+
+    fn create<P>(
+        config: Self::Config,
+        mut codec: Codec,
+        first_round: &RoundID,
+        parties: &P,
+        self_party: Party,
+        party_data: &[Party]
+    ) -> Result<Self, Self::CreateError<P::Error>>
+    where
+        P: Parties<RoundID, PartyID> {
+        let (hash, outbound_config) = config.take();
+        let self_hash = hash
+            .hashid(&mut codec, &self_party)
+            .map_err(|err| PBFTProtoStateCreateError::Encode { err: err })?;
+        let iter = parties
+            .parties(first_round)
+            .map_err(|err| PBFTProtoStateCreateError::Parties { err: err })?;
+        let hint = match iter.size_hint() {
+            (_, Some(hint)) | (hint, _) => hint
+        };
+        let mut party_hashes = HashMap::with_capacity(hint);
+        let mut hash_parties = HashMap::with_capacity(hint);
+
+        for party_id in iter {
+            let idx: usize = party_id.clone().into();
+            let party = &party_data[idx];
+            let hash = hash.hashid(&mut codec, party).map_err(|err| {
+                PBFTProtoStateCreateError::Encode { err: err }
+            })?;
+
+            party_hashes.insert(party_id.clone(), hash.clone());
+            hash_parties.insert(hash, party_id.clone());
+        }
+
+        Ok(PBFTProtoState {
+            outbound_config: outbound_config,
+            party_hashes: party_hashes,
+            hash_parties: hash_parties,
+            leader: PBFTLeader::None { hint: None },
+            self_hash: self_hash,
+            hash: hash
+        })
+    }
+}
+
+impl<RoundID, PartyID> ProtoState<RoundID, PartyID> for PBFTProtoState<PartyID>
+where
+    PartyID: Clone + Display + Eq + Hash + Into<usize>
+{
+    type Oper = PBFTRoundResult<PbftRequest>;
+    type UpdateError = PBFTProtoStateUpdateError;
+
+    fn update<P>(
+        &mut self,
+        _parties: &mut P,
+        oper: PBFTRoundResult<PbftRequest>
+    ) -> Result<(), Self::UpdateError>
+    where
+        P: Parties<RoundID, PartyID> {
+        match oper {
+            PBFTRoundResult::Complete {
+                req: PbftRequest::View(PbftView { id })
+            } => {
+                let id = self.hash.wrap_hashed_bytes(&id).map_err(|err| {
+                    PBFTProtoStateUpdateError::BadSize { err: err }
+                })?;
+
+                if self.self_hash == id {
+                    info!(target: "pbft-proto-state",
+                          "we became leader of consensus pool");
+
+                    self.leader = PBFTLeader::This;
+
+                    Ok(())
+                } else {
+                    match self.hash_parties.get(&id) {
+                        Some(party) => {
+                            info!(target: "pbft-proto-state",
+                                  "party {} became leader of consensus pool",
+                                  party);
+
+                            self.leader = PBFTLeader::Other {
+                                party: party.clone()
+                            };
+
+                            Ok(())
+                        }
+                        None => {
+                            Err(PBFTProtoStateUpdateError::BadParty { id: id })
+                        }
+                    }
+                }
+            }
+            PBFTRoundResult::Complete {
+                req: PbftRequest::Members(_)
+            } => {
+                error!(target: "pbft-proto-state",
+                       "member update not yet implemented!");
+
+                Ok(())
+            }
+            PBFTRoundResult::Complete {
+                req: PbftRequest::Payload(_)
+            } => Ok(()),
+            PBFTRoundResult::Fail { fail: votes } => {
+                self.update_leader_hint(votes)
+            }
+        }
+    }
+}
+
+impl<RoundID, PartyID>
+    ProtoStateRound<RoundID, PartyID, PbftMsg, PBFTOutbound<RoundID>>
+    for PBFTProtoState<PartyID>
+where
+    RoundID: Clone + Display + From<u128> + Into<u128> + Ord,
+    PartyID: Clone + Display + Eq + Hash + From<usize> + Into<usize>
+{
+    type CreateRoundError = PBFTRoundStateCreateError<PartyID>;
+    type Info = PBFTRoundInfo<OutboundPartyIdx>;
+    type Round = PBFTRoundState<PbftRequest>;
+
+    fn create_round(
+        &mut self,
+        parties: &PartyIDMap<OutboundPartyIdx, PartyID>
+    ) -> Result<
+        Option<(
+            Self::Round,
+            PBFTRoundInfo<OutboundPartyIdx>,
+            PBFTOutbound<RoundID>
+        )>,
+        PBFTRoundStateCreateError<PartyID>
+    > {
+        let nparties = self.nparties();
+        let mut out =
+            PBFTOutbound::create(nparties - 1, self.outbound_config.clone());
+        let leader = match &self.leader {
+            PBFTLeader::Other { party } => match parties.party_idx(party) {
+                Some(id) => Ok(PBFTLeader::Other { party: id.clone() }),
+                None => Err(PBFTRoundStateCreateError::BadParty {
+                    party: party.clone()
+                })
+            },
+            PBFTLeader::This => Ok(PBFTLeader::This),
+            // We only need the hint for selecting leaders; it's not
+            // necessary for running the round.
+            PBFTLeader::None { .. } => Ok(PBFTLeader::None { hint: () })
+        }?;
+        let info = PBFTRoundInfo { leader: leader };
+
+        match &self.leader {
+            // We're not the leader; don't set up any initial request.
+            PBFTLeader::Other { .. } => {
+                debug!(target: "pbft-proto-state",
+                       "someone else is the leader, generating empty");
+
+                let round = PBFTRoundState::new(nparties);
+
+                Ok(Some((round, info, out)))
+            }
+            PBFTLeader::This => {
+                debug!(target: "pbft-proto-state",
+                       "we are the leader, not generating round");
+
+                // XXX This is temporary, for testing
+                Ok(None)
+            }
+            // There is no leader, but we have a hint proposing ourself.
+            PBFTLeader::None {
+                hint: Some(PBFTLeaderHint::This)
+            } => {
+                debug!(target: "pbft-proto-state",
+                       "no one is the leader, hint proposes ourself");
+
+                let req = PbftRequest::view_change(&self.self_hash);
+                let round = PBFTRoundState::with_req(&mut out, nparties, req);
+
+                Ok(Some((round, info, out)))
+            }
+            // There is no leader, but we have a hint proposing someone else.
+            PBFTLeader::None {
+                hint: Some(PBFTLeaderHint::Other { party })
+            } => {
+                debug!(target: "pbft-proto-state",
+                       "no one is the leader, hint proposes {}",
+                       party);
+
+                match self.party_hashes.get(party) {
+                    Some(hash) => {
+                        let req = PbftRequest::view_change(hash);
+                        let round =
+                            PBFTRoundState::with_req(&mut out, nparties, req);
+
+                        Ok(Some((round, info, out)))
+                    }
+                    // This shouldn't ever happen.
+                    None => Err(PBFTRoundStateCreateError::BadHint {
+                        party: party.clone()
+                    })
+                }
+            }
+            // There is no leader: propose ourselves.
+            PBFTLeader::None { hint: None } => {
+                debug!(target: "pbft-proto-state",
+                       "no one is the leader, generating view change");
+
+                // XXX this needs a better mechanism for picking a leader.
+                let parties: Vec<&CompoundHashID> =
+                    self.party_hashes.values().collect();
+                let idx = (random::<usize>() % parties.len()) + 1;
+
+                let hash = if idx == 0 {
+                    &self.self_hash
+                } else {
+                    parties[idx - 1]
+                };
+
+                let req = PbftRequest::view_change(hash);
+                let round = PBFTRoundState::with_req(&mut out, nparties, req);
+
+                Ok(Some((round, info, out)))
+            }
+        }
+    }
+}
+
+impl<RoundID, Party, Out>
+    RoundState<
+        RoundID,
+        Party,
+        PBFTRoundResult<PbftRequest>,
+        PbftContent,
+        PBFTRoundInfo<Party>,
+        Out
+    > for PBFTRoundState<PbftRequest>
+where
+    Out: Outbound<RoundID, PbftMsg> + PBFTOutboundSend<PbftRequest>,
+    RoundID: Clone + Display + From<u128> + Into<u128> + Ord,
+    Party: Clone + Display + From<usize> + Into<usize>
+{
+    fn recv(
+        self,
+        out: &mut Out,
+        info: &PBFTRoundInfo<Party>,
+        round: &RoundID,
+        party: &Party,
+        msg: PbftContent
+    ) -> RoundStateUpdate<Self, PBFTRoundResult<PbftRequest>> {
+        match msg {
+            PbftContent::UpdateAck(PbftUpdateAck { update, .. }) |
+            PbftContent::Update(update) => match update {
+                PbftStateUpdate::Prepare(req) => {
+                    self.prepare(out, round, &info.leader, party, req)
+                }
+                PbftStateUpdate::Commit(req) => {
+                    self.commit(out, round, &info.leader, party, req)
+                }
+                PbftStateUpdate::Complete(req) => {
+                    self.complete(out, round, &info.leader, party, req)
+                }
+                PbftStateUpdate::Fail(_) => self.fail(out, round, party)
+            },
+            _ => RoundStateUpdate::Pending { pending: self }
+        }
+    }
+}
+
+impl<Party> Display for PBFTRoundStateCreateError<Party>
+where
+    Party: Display
+{
+    fn fmt(
+        &self,
+        f: &mut Formatter<'_>
+    ) -> Result<(), Error> {
+        match self {
+            PBFTRoundStateCreateError::BadParty { party } => {
+                write!(f, "unknown party {}", party)
+            }
+            PBFTRoundStateCreateError::BadHint { party } => {
+                write!(f, "unknown party {} in leader hint", party)
+            }
+        }
+    }
+}
+
+impl<Parties, Encode> Display for PBFTProtoStateCreateError<Parties, Encode>
+where
+    Parties: Display,
+    Encode: Display
+{
+    fn fmt(
+        &self,
+        f: &mut Formatter<'_>
+    ) -> Result<(), Error> {
+        match self {
+            PBFTProtoStateCreateError::Parties { err } => err.fmt(f),
+            PBFTProtoStateCreateError::Encode { err } => err.fmt(f)
+        }
+    }
+}
+
+impl Display for PBFTProtoStateUpdateError {
+    fn fmt(
+        &self,
+        f: &mut Formatter<'_>
+    ) -> Result<(), Error> {
+        match self {
+            PBFTProtoStateUpdateError::BadSize { err } => write!(f, "{}", err),
+            PBFTProtoStateUpdateError::BadParty { id } => {
+                write!(f, "bad party hash: {}", id)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+use std::fmt::Debug;
+
+#[cfg(test)]
+use crate::init;
+
+#[cfg(test)]
+struct TestOutbound<Req: Clone> {
+    prepare: Option<Req>,
+    commit: Option<Req>,
+    complete: Option<Req>,
+    fail: bool
+}
+
+#[cfg(test)]
+impl<Req: Clone> TestOutbound<Req> {
+    #[inline]
+    fn new() -> Self {
+        TestOutbound {
+            prepare: None,
+            commit: None,
+            complete: None,
+            fail: false
+        }
+    }
+}
+
+#[cfg(test)]
+impl<Req: Clone> PBFTOutboundSend<Req> for TestOutbound<Req> {
+    #[inline]
+    fn send_prepare(
+        &mut self,
+        req: &Req
+    ) {
+        assert!(self.prepare.is_none());
+
+        self.prepare = Some(req.clone())
+    }
+
+    #[inline]
+    fn send_commit(
+        &mut self,
+        req: &Req
+    ) {
+        assert!(self.commit.is_none());
+
+        self.commit = Some(req.clone())
+    }
+
+    #[inline]
+    fn send_complete(
+        &mut self,
+        req: &Req
+    ) {
+        assert!(self.complete.is_none());
+
+        self.complete = Some(req.clone())
+    }
+
+    #[inline]
+    fn send_fail(&mut self) {
+        self.fail = true
+    }
+}
+
+#[cfg(test)]
+fn check_votes<Req>(
+    votes: &HashMap<Req, BitVec>,
+    voted: &BitVec,
+    lead: usize,
+    expected: &HashMap<usize, Req>
+) where
+    Req: Clone + Debug + Display + Eq + Hash {
+    let mut party_votes = HashMap::with_capacity(voted.len());
+    let mut lead_votes = 0;
+
+    for (req, req_votes) in votes {
+        for i in req_votes.iter_ones() {
+            assert!(!party_votes.contains_key(&i));
+            assert!(voted[i]);
+
+            lead_votes = lead_votes.max(req_votes.count_ones());
+            party_votes.insert(i, req.clone());
+        }
+    }
+
+    assert_eq!(&party_votes, expected);
+    assert_eq!(lead, lead_votes);
+}
+
+#[cfg(test)]
+fn check_consistency<Req: Clone>(
+    state: &RoundStateUpdate<PBFTRoundState<Req>, PBFTRoundResult<Req>>,
+    outbound: &TestOutbound<Req>,
+    prepare_votes: &HashMap<usize, Req>,
+    commit_votes: &HashMap<usize, Req>,
+    _self_party: usize
+) where
+    Req: Clone + Debug + Display + Eq + Hash {
+    match state {
+        RoundStateUpdate::Pending {
+            pending: PBFTRoundState::Prepare { prepare }
+        } => {
+            check_votes(
+                &prepare.prepare_votes,
+                &prepare.prepare_voted,
+                prepare.prepare_lead,
+                &prepare_votes
+            );
+            check_votes(
+                &prepare.commit_votes,
+                &prepare.commit_voted,
+                prepare.commit_lead,
+                &commit_votes
+            );
+
+            assert_eq!(
+                prepare.prepare_remaining,
+                prepare.prepare_voted.len() -
+                    prepare.prepare_voted.count_ones()
+            );
+            assert_eq!(
+                prepare.commit_remaining,
+                prepare.commit_voted.len() - prepare.commit_voted.count_ones()
+            );
+
+            match (&outbound.prepare, &prepare.prepared) {
+                (None, Some(_)) => panic!("prepare has value, but no outbound"),
+                (Some(_), None) => panic!("outbound has value, but no prepare"),
+                (Some(a), Some(b)) => assert_eq!(a, b),
+                _ => {}
+            }
+        }
+        RoundStateUpdate::Pending {
+            pending: PBFTRoundState::Commit { commit }
+        } => {
+            check_votes(
+                &commit.commit_votes,
+                &commit.commit_voted,
+                commit.commit_lead,
+                &commit_votes
+            );
+
+            assert_eq!(
+                commit.commit_remaining,
+                commit.commit_voted.len() - commit.commit_voted.count_ones()
+            );
+
+            match (&outbound.commit, &commit.commit) {
+                (None, Some(_)) => panic!("commit has value, but no outbound"),
+                (Some(_), None) => panic!("outbound has value, but no commit"),
+                (Some(a), Some(b)) => assert_eq!(a, b),
+                _ => {}
+            }
+        }
+        RoundStateUpdate::Resolved {
+            resolved: PBFTRoundResult::Complete { req }
+        } => match &outbound.complete {
+            None => panic!("inconsistent state and outbound"),
+            Some(out) => assert_eq!(req, out)
+        },
+        RoundStateUpdate::Resolved {
+            resolved: PBFTRoundResult::Fail { .. }
+        } => {
+            assert!(outbound.fail);
+        }
+    }
+}
+
+#[cfg(test)]
+const TOLERANCES: [(usize, usize); 102] = [
+    (4, 1),
+    (5, 1),
+    (6, 1),
+    (7, 2),
+    (8, 2),
+    (9, 2),
+    (10, 3),
+    (11, 3),
+    (12, 3),
+    (13, 4),
+    (14, 4),
+    (15, 4),
+    (16, 5),
+    (17, 5),
+    (18, 5),
+    (19, 6),
+    (20, 6),
+    (21, 6),
+    (22, 7),
+    (23, 7),
+    (24, 7),
+    (25, 8),
+    (26, 8),
+    (27, 8),
+    (28, 9),
+    (29, 9),
+    (30, 9),
+    (31, 10),
+    (32, 10),
+    (33, 10),
+    (34, 11),
+    (35, 11),
+    (36, 11),
+    (37, 12),
+    (38, 12),
+    (39, 12),
+    (40, 13),
+    (41, 13),
+    (42, 13),
+    (43, 14),
+    (44, 14),
+    (45, 14),
+    (46, 15),
+    (47, 15),
+    (48, 15),
+    (49, 16),
+    (50, 16),
+    (51, 16),
+    (52, 17),
+    (53, 17),
+    (54, 17),
+    (55, 18),
+    (56, 18),
+    (57, 18),
+    (58, 19),
+    (59, 19),
+    (60, 19),
+    (61, 20),
+    (62, 20),
+    (63, 20),
+    (64, 21),
+    (65, 21),
+    (66, 21),
+    (67, 22),
+    (68, 22),
+    (69, 22),
+    (70, 23),
+    (71, 23),
+    (72, 23),
+    (73, 24),
+    (74, 24),
+    (75, 24),
+    (76, 25),
+    (77, 25),
+    (78, 25),
+    (79, 26),
+    (80, 26),
+    (81, 26),
+    (82, 27),
+    (83, 27),
+    (84, 27),
+    (85, 28),
+    (86, 28),
+    (87, 28),
+    (88, 29),
+    (89, 29),
+    (90, 29),
+    (91, 30),
+    (92, 30),
+    (93, 30),
+    (94, 31),
+    (95, 31),
+    (96, 31),
+    (97, 32),
+    (98, 32),
+    (99, 32),
+    (100, 33),
+    (101, 33),
+    (102, 33),
+    (103, 34),
+    (104, 34),
+    (105, 34)
+];
+
+#[test]
+fn test_new() {
+    init();
+
+    for (nparties, nfaults) in TOLERANCES {
+        let state: PBFTRoundState<usize> = PBFTRoundState::new(nparties);
+
+        match state {
+            PBFTRoundState::Prepare { prepare } => {
+                let quorum = nparties - nfaults;
+
+                assert!(quorum >= (2 * nfaults) + 1);
+                assert_eq!(prepare.quorum, quorum);
+                assert!(prepare.prepared.is_none());
+                assert!(prepare.prepare_votes.is_empty());
+                assert_eq!(prepare.prepare_voted.count_ones(), 0);
+                assert_eq!(prepare.prepare_remaining, nparties);
+                assert_eq!(prepare.prepare_lead, 0);
+                assert!(prepare.commit_votes.is_empty());
+                assert_eq!(prepare.commit_voted.count_ones(), 0);
+                assert_eq!(prepare.commit_remaining, nparties);
+                assert_eq!(prepare.commit_lead, 0);
+            }
+            _ => panic!("Expected prepare state")
+        }
+    }
+}
+
+#[test]
+fn test_leader() {
+    init();
+
+    for (nparties, nfaults) in TOLERANCES {
+        let mut outbound = TestOutbound::new();
+        let proposal = 2;
+        let state: PBFTRoundState<usize> =
+            PBFTRoundState::with_req(&mut outbound, nparties, proposal);
+        let expect_prepare = [(0, proposal)].iter().cloned().collect();
+
+        match &state {
+            PBFTRoundState::Prepare { prepare } => {
+                let quorum = nparties - nfaults;
+
+                assert!(quorum >= (2 * nfaults) + 1);
+                assert_eq!(prepare.quorum, quorum);
+
+                assert_eq!(prepare.prepared, Some(proposal));
+                assert_eq!(prepare.prepare_voted.count_ones(), 1);
+                assert_eq!(prepare.prepare_remaining, nparties - 1);
+                assert_eq!(prepare.prepare_lead, 1);
+                assert_eq!(prepare.prepare_votes.len(), 1);
+
+                let votes = prepare
+                    .prepare_votes
+                    .get(&proposal)
+                    .expect("Expected some");
+
+                assert_eq!(votes.count_ones(), 1);
+                assert!(votes[0]);
+
+                assert!(prepare.commit_votes.is_empty());
+                assert_eq!(prepare.commit_voted.count_ones(), 0);
+                assert_eq!(prepare.commit_remaining, nparties);
+                assert_eq!(prepare.commit_lead, 0);
+            }
+            _ => panic!("Expected prepare state")
+        }
+
+        check_consistency(
+            &RoundStateUpdate::Pending { pending: state },
+            &outbound,
+            &expect_prepare,
+            &HashMap::new(),
+            0
+        );
+    }
+}
+
+#[cfg(test)]
+enum ConsensusTestOp {
+    Prepare { req: usize, party: usize },
+    Commit { req: usize, party: usize },
+    Complete { req: usize, party: usize },
+    Fail { party: usize }
+}
+
+#[cfg(test)]
+fn consensus_test<F>(
+    init_proposal: Option<usize>,
+    leader: &PBFTLeader<usize, ()>,
+    expect_prepare: &[(usize, usize)],
+    expect_commit: &[(usize, usize)],
+    ops: &[ConsensusTestOp],
+    check: F
+) where
+    F: FnOnce(RoundStateUpdate<PBFTRoundState<usize>, PBFTRoundResult<usize>>) {
+    init();
+
+    let round = 1337;
+    let nparties = 10;
+    let mut outbound = TestOutbound::new();
+    let state: PBFTRoundState<usize> = match init_proposal {
+        Some(proposal) => {
+            PBFTRoundState::with_req(&mut outbound, nparties, proposal)
+        }
+        None => PBFTRoundState::new(nparties)
+    };
+    let expect_prepare = expect_prepare.iter().cloned().collect();
+    let expect_commit = expect_commit.iter().cloned().collect();
+    let mut update = RoundStateUpdate::Pending { pending: state };
+
+    for op in ops {
+        update = match update {
+            RoundStateUpdate::Pending { pending } => match op {
+                ConsensusTestOp::Prepare { req, party } => {
+                    let party = party - 1;
+
+                    pending.prepare(&mut outbound, &round, leader, &party, *req)
+                }
+                ConsensusTestOp::Commit { req, party } => {
+                    let party = party - 1;
+
+                    pending.commit(&mut outbound, &round, leader, &party, *req)
+                }
+                ConsensusTestOp::Complete { req, party } => {
+                    let party = party - 1;
+
+                    pending.complete(
+                        &mut outbound,
+                        &round,
+                        leader,
+                        &party,
+                        *req
+                    )
+                }
+                ConsensusTestOp::Fail { party } => {
+                    let party = party - 1;
+
+                    pending.fail(&mut outbound, &round, &party)
+                }
+            },
+            _ => panic!("protocol terminated unexpectedly")
+        }
+    }
+
+    check_consistency(
+        &update,
+        &outbound,
+        &expect_prepare,
+        &expect_commit,
+        SELF_PARTY
+    );
+    check(update);
+}
+
+#[test]
+fn test_withreq_handle_prepare_nolead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[ConsensusTestOp::Prepare {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_selflead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[ConsensusTestOp::Prepare {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_nonlead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[ConsensusTestOp::Prepare {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_lead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[ConsensusTestOp::Prepare {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_prepare_nonlead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[],
+        &[ConsensusTestOp::Prepare {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_prepare_lead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[ConsensusTestOp::Prepare {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_nolead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_selflead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_nonlead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_lead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_prepare_nonlead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_prepare_lead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_nolead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_selflead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_nonlead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_lead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_prepare_nonlead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_prepare_lead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_nolead_consistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_selflead_consistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_nonlead_consistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_lead_consistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_prepare_nonlead_consistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_prepare_lead_consistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+// XXX We should probably discard inconsistent commits.
+
+#[test]
+fn test_withreq_handle_prepare_nolead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, inconsistent)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_selflead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, inconsistent)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_nonlead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, inconsistent)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_lead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, inconsistent)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_prepare_nonlead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, inconsistent)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_prepare_lead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, inconsistent)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_nolead_superceding_complete() {
+    let party = 1;
+    let proposal = 2;
+    let superceding = 3;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, superceding)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: superceding,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_selflead_superceding_complete() {
+    let party = 1;
+    let proposal = 2;
+    let superceding = 3;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, superceding)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: superceding,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_nonlead_superceding_complete() {
+    let party = 1;
+    let proposal = 2;
+    let superceding = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, superceding)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: superceding,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_lead_superceding_complete() {
+    let party = 1;
+    let proposal = 2;
+    let superceding = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, superceding)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: superceding,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_prepare_nonlead_superceding_complete() {
+    let party = 1;
+    let proposal = 2;
+    let superceding = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, superceding)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: superceding,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_prepare_lead_superceding_complete() {
+    let party = 1;
+    let proposal = 2;
+    let superceding = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, superceding)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: superceding,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_nolead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_selflead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_nonlead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_prepare_lead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_prepare_nonlead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_prepare_lead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_nolead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[ConsensusTestOp::Commit {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_selflead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[ConsensusTestOp::Commit {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_nonlead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[ConsensusTestOp::Commit {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_lead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[ConsensusTestOp::Commit {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_commit_nonlead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, proposal)],
+        &[ConsensusTestOp::Commit {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_commit_lead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[ConsensusTestOp::Commit {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_nolead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_selflead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_nonlead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_lead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_commit_nonlead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_commit_lead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_nolead_consistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_selflead_consistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_nonlead_consistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_lead_consistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_commit_nonlead_consistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_commit_lead_consistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_nolead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_selflead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_nonlead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_lead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_commit_nonlead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_commit_lead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_nolead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_selflead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_nonlead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_lead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_commit_nonlead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_commit_lead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_nolead_superceding_complete() {
+    let party = 1;
+    let proposal = 2;
+    let superceding = 3;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: superceding,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_selflead_superceding_complete() {
+    let party = 1;
+    let proposal = 2;
+    let superceding = 3;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: superceding,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_nonlead_superceding_complete() {
+    let party = 1;
+    let proposal = 2;
+    let superceding = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: superceding,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_lead_superceding_complete() {
+    let party = 1;
+    let proposal = 2;
+    let superceding = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: superceding,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_commit_nonlead_superceding_complete() {
+    let party = 1;
+    let proposal = 2;
+    let superceding = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: superceding,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_commit_lead_superceding_complete() {
+    let party = 1;
+    let proposal = 2;
+    let superceding = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: superceding,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_nolead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_selflead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_nonlead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_commit_lead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_commit_nonlead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_commit_lead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_nolead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[ConsensusTestOp::Complete {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_selflead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[ConsensusTestOp::Complete {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_nonlead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[ConsensusTestOp::Complete {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_lead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[ConsensusTestOp::Complete {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_complete_nonlead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, proposal)],
+        &[ConsensusTestOp::Complete {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_complete_lead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[ConsensusTestOp::Complete {
+            req: proposal,
+            party: party
+        }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_nolead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_selflead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_nonlead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_lead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_complete_nonlead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_complete_lead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_nolead_consistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_selflead_consistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_nonlead_consistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_lead_consistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_complete_nonlead_consistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_complete_lead_consistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_nolead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_selflead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_nonlead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_lead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_complete_nonlead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_complete_lead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_nolead_consistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_selflead_consistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_nonlead_consistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_lead_consistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_complete_nonlead_consistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_complete_lead_consistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_nolead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_selflead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_nonlead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_lead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_complete_nonlead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_complete_lead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_nolead_inconsistent_complete() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_selflead_inconsistent_complete() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_nonlead_inconsistent_complete() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_lead_inconsistent_complete() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_complete_nonlead_inconsistent_complete() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_complete_lead_inconsistent_complete() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_nolead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_selflead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_nonlead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_complete_lead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_complete_nonlead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_complete_lead_fail() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal), (party, proposal)],
+        &[(party, proposal)],
+        &[
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: party
+            },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_nolead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[ConsensusTestOp::Fail { party: party }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_selflead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[ConsensusTestOp::Fail { party: party }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_nonlead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[ConsensusTestOp::Fail { party: party }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_lead() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[ConsensusTestOp::Fail { party: party }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_fail_nonlead() {
+    let party = 1;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[],
+        &[],
+        &[ConsensusTestOp::Fail { party: party }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_fail_lead() {
+    let party = 1;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[],
+        &[],
+        &[ConsensusTestOp::Fail { party: party }],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_nolead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_selflead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_nonlead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_lead_idempotent() {
+    let party = 1;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_fail_nonlead_idempotent() {
+    let party = 1;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_fail_lead_idempotent() {
+    let party = 1;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Fail { party: party }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_nolead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_selflead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_nonlead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_lead_inconsistent_prepare() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_fail_nonlead_inconsistent_prepare() {
+    let party = 1;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_fail_lead_inconsistent_prepare() {
+    let party = 1;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Prepare {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_nolead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_selflead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_nonlead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_lead_inconsistent_commit() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_fail_nonlead_inconsistent_commit() {
+    let party = 1;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_fail_lead_inconsistent_commit() {
+    let party = 1;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_nolead_inconsistent_complete() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_selflead_inconsistent_complete() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_nonlead_inconsistent_complete() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_handle_fail_lead_inconsistent_complete() {
+    let party = 1;
+    let proposal = 2;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare:
+                            PrepareState {
+                                prepared: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_fail_nonlead_inconsistent_complete() {
+    let party = 1;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 2 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_handle_fail_lead_inconsistent_complete() {
+    let party = 1;
+    let inconsistent = 3;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: party },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: party
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Prepare {
+                        prepare: PrepareState { prepared: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected prepare state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_basic_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_basic_selflead() {
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_basic_nonlead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_basic_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_basic_nonlead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_basic_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_initial_nolead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(overridden),
+        &leader,
+        &[
+            (SELF_PARTY, overridden),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, overridden)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_initial_selflead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(overridden),
+        &leader,
+        &[
+            (SELF_PARTY, overridden),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, overridden)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_initial_nonlead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(overridden),
+        &leader,
+        &[
+            (SELF_PARTY, overridden),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, overridden)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_initial_lead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(overridden),
+        &leader,
+        &[
+            (SELF_PARTY, overridden),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, overridden)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_prepare_nolead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: overridden,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_prepare_selflead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_prepare_nonlead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_prepare_lead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, overridden),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: overridden,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_override_prepare_nonlead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 8
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_override_prepare_lead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, overridden),
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[(SELF_PARTY, overridden)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 8
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_override_prepare_lead_wins() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, overridden),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: overridden,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 8
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_override_prepare_lead_self_wins() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 7 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, overridden),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: overridden,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_commit_nolead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, overridden),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (2, overridden)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_commit_selflead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, overridden)],
+        &[
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_commit_nonlead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, overridden)],
+        &[
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_commit_lead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, overridden),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (2, overridden)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_override_commit_nonlead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[(1, overridden)],
+        &[
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 8
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_override_commit_lead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, overridden),
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[(SELF_PARTY, overridden), (1, overridden)],
+        &[
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 8
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_override_commit_lead_wins() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, overridden),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (2, overridden)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 8
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_override_commit_lead_self_wins() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 7 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, overridden),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (2, overridden)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_complete_nolead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, overridden),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (2, overridden)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_complete_selflead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, overridden)],
+        &[
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_complete_nonlead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, overridden)],
+        &[
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_complete_lead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, overridden),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (2, overridden)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_override_complete_nonlead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[(1, overridden)],
+        &[
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 8
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_override_complete_lead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, overridden),
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[(SELF_PARTY, overridden), (1, overridden)],
+        &[
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 8
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_override_complete_lead_wins() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, overridden),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (2, overridden)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 8
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_override_complete_lead_self_wins() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 7 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, overridden),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (2, overridden)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_fail_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_fail_selflead() {
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_fail_nonlead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_finish_prepare_override_fail_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_override_fail_nonlead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 8
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_override_fail_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 8
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_override_fail_lead_wins() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 8
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_empty_finish_prepare_override_fail_lead_self_wins() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 7 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_deadlock_prepare_nolead() {
+    let a = 1;
+    let b = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, b),
+            (5, b),
+            (6, b),
+            (7, b)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: b, party: 4 },
+            ConsensusTestOp::Prepare { req: b, party: 5 },
+            ConsensusTestOp::Prepare { req: b, party: 6 },
+            ConsensusTestOp::Prepare { req: b, party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_deadlock_prepare_selflead() {
+    let a = 1;
+    let b = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, b),
+            (5, b),
+            (6, b),
+            (7, b)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: b, party: 4 },
+            ConsensusTestOp::Prepare { req: b, party: 5 },
+            ConsensusTestOp::Prepare { req: b, party: 6 },
+            ConsensusTestOp::Prepare { req: b, party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_deadlock_prepare_nonlead() {
+    let a = 1;
+    let b = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, b),
+            (5, b),
+            (6, b),
+            (7, b)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: b, party: 4 },
+            ConsensusTestOp::Prepare { req: b, party: 5 },
+            ConsensusTestOp::Prepare { req: b, party: 6 },
+            ConsensusTestOp::Prepare { req: b, party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_deadlock_prepare_lead() {
+    let a = 1;
+    let b = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, b),
+            (5, b),
+            (6, b),
+            (7, b)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: b, party: 4 },
+            ConsensusTestOp::Prepare { req: b, party: 5 },
+            ConsensusTestOp::Prepare { req: b, party: 6 },
+            ConsensusTestOp::Prepare { req: b, party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_empty_deadlock_prepare_nonlead() {
+    let a = 1;
+    let b = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, b),
+            (6, b),
+            (7, b),
+            (8, b)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: b, party: 5 },
+            ConsensusTestOp::Prepare { req: b, party: 6 },
+            ConsensusTestOp::Prepare { req: b, party: 7 },
+            ConsensusTestOp::Prepare { req: b, party: 8 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_empty_deadlock_prepare_lead() {
+    let a = 1;
+    let b = 2;
+    let leader = PBFTLeader::Other { party: 7 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, b),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, b),
+            (6, b),
+            (7, b)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: b, party: 5 },
+            ConsensusTestOp::Prepare { req: b, party: 6 },
+            ConsensusTestOp::Prepare { req: b, party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_all_fail_prepare_nolead() {
+    let proposal = 0;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_all_fail_prepare_selflead() {
+    let proposal = 0;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_all_fail_prepare_nonlead() {
+    let proposal = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_all_fail_prepare_lead() {
+    let proposal = 0;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_empty_all_fail_prepare_nonlead() {
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_empty_all_fail_prepare_lead() {
+    let proposal = 0;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, proposal)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_fail_prepare_nolead() {
+    let proposal = 0;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Fail { party: 7 },
+            ConsensusTestOp::Fail { party: 8 },
+            ConsensusTestOp::Fail { party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_fail_prepare_selflead() {
+    let proposal = 0;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Fail { party: 7 },
+            ConsensusTestOp::Fail { party: 8 },
+            ConsensusTestOp::Fail { party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_fail_prepare_lead() {
+    let proposal = 0;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Fail { party: 7 },
+            ConsensusTestOp::Fail { party: 8 },
+            ConsensusTestOp::Fail { party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_empty_fail_prepare_nonlead() {
+    let proposal = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Fail { party: 7 },
+            ConsensusTestOp::Fail { party: 8 },
+            ConsensusTestOp::Fail { party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_empty_fail_prepare_lead() {
+    let proposal = 0;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Fail { party: 7 },
+            ConsensusTestOp::Fail { party: 8 },
+            ConsensusTestOp::Fail { party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_doomed_prepare_nolead() {
+    let a = 1;
+    let b = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[(SELF_PARTY, a), (4, b)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Prepare { req: b, party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_doomed_prepare_selflead() {
+    let a = 1;
+    let b = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[(SELF_PARTY, a), (4, b)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Prepare { req: b, party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_doomed_prepare_nonlead() {
+    let a = 1;
+    let b = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[(SELF_PARTY, a), (4, b)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Prepare { req: b, party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_withreq_doomed_prepare_lead() {
+    let a = 1;
+    let b = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[(SELF_PARTY, a), (4, b)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Prepare { req: b, party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_empty_doomed_prepare_nonlead() {
+    let a = 1;
+    let b = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(4, a), (4, b)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: b, party: 5 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_empty_doomed_prepare_lead() {
+    let a = 1;
+    let b = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(SELF_PARTY, b), (4, b), (5, a)],
+        &[],
+        &[
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Prepare { req: b, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_selflead() {
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_nonlead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_noprepared_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_noprepared_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (9, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_idempotent_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_idempotent_selflead() {
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_idempotent_nonlead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_idempotent_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_idempotent_noprepared_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_idempotent_noprepared_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (9, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_commit_nolead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_commit_selflead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_commit_nonlead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_commit_lead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_commit_noprepared_nolead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_commit_noprepared_lead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (9, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_consistent_complete_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_consistent_complete_selflead() {
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_consistent_complete_nonlead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_consistent_complete_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_consistent_complete_noprepared_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_consistent_complete_noprepared_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (9, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_complete_nolead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_complete_selflead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_complete_nonlead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_complete_lead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_complete_noprepared_nolead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_complete_noprepared_lead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (9, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_fail_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_fail_selflead() {
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_fail_nonlead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_fail_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_fail_noprepared_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_commit_inconsistent_fail_noprepared_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (9, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Fail { party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_selflead() {
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_nonlead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_noprepared_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_noprepared_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (9, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_idempotent_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_idempotent_selflead() {
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_idempotent_nonlead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_idempotent_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_idempotent_noprepared_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_idempotent_noprepared_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (9, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_inconsistent_commit_nolead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_inconsistent_commit_selflead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_inconsistent_commit_nonlead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_inconsistent_commit_lead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_inconsistent_commit_noprepared_nolead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_inconsistent_commit_noprepared_lead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (9, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_inconsistent_fail_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_inconsistent_fail_selflead() {
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_inconsistent_fail_nonlead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_inconsistent_fail_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_inconsistent_fail_noprepared_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(1, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_complete_inconsistent_fail_noprepared_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[(SELF_PARTY, proposal), (9, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Fail { party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_selflead() {
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_nonlead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_noprepared_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_noprepared_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Fail { party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_idempotent_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_idempotent_selflead() {
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_idempotent_nonlead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_idempotent_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_idempotent_noprepared_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_idempotent_noprepared_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Fail { party: 9 },
+            ConsensusTestOp::Fail { party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_inconsistent_commit_nolead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_inconsistent_commit_selflead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_inconsistent_commit_nonlead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_inconsistent_commit_lead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_inconsistent_commit_noprepared_nolead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_inconsistent_commit_noprepared_lead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Fail { party: 9 },
+            ConsensusTestOp::Commit {
+                req: inconsistent,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_inconsistent_complete_nolead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_inconsistent_complete_selflead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_inconsistent_complete_nonlead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_inconsistent_complete_lead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[(SELF_PARTY, proposal)],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit:
+                            CommitState {
+                                commit: Some(_), ..
+                            }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_inconsistent_complete_noprepared_nolead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: 1
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_commit_handle_fail_inconsistent_complete_noprepared_lead() {
+    let proposal = 2;
+    let inconsistent = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Fail { party: 9 },
+            ConsensusTestOp::Complete {
+                req: inconsistent,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Pending {
+                pending:
+                    PBFTRoundState::Commit {
+                        commit: CommitState { commit: None, .. }
+                    }
+            } => {}
+            _ => panic!("Expected commit state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_basic_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_basic_selflead() {
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_basic_nonlead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_basic_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(proposal),
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_basic_noprepared_nolead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_basic_noprepared_lead() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_basic_carryover() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_basic_carryover_commit() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_basic_carryover_complete() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_basic_decide_both() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_basic_decide_both_commit() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_basic_decide_both_complete() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_nolead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(overridden),
+        &leader,
+        &[
+            (SELF_PARTY, overridden),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[
+            (SELF_PARTY, overridden),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_selflead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(overridden),
+        &leader,
+        &[
+            (SELF_PARTY, overridden),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[
+            (SELF_PARTY, overridden),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_nonlead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(overridden),
+        &leader,
+        &[
+            (SELF_PARTY, overridden),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[
+            (SELF_PARTY, overridden),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_lead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(overridden),
+        &leader,
+        &[
+            (SELF_PARTY, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[
+            (SELF_PARTY, overridden),
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 8
+            },
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 8
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_noprepared_nolead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 8
+            },
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 8
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_noprepared_lead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[
+            (SELF_PARTY, overridden),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (9, overridden)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 9
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_carryover() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, overridden)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_carryover_commit() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (7, overridden),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_carryover_complete() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (7, overridden),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_decide_both() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (7, overridden),
+            (6, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_decide_both_commit() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (7, overridden),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_decide_both_complete() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (7, overridden),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: overridden,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_complete_lead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(overridden),
+        &leader,
+        &[
+            (SELF_PARTY, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[
+            (SELF_PARTY, overridden),
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 8
+            },
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 8
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_complete_noprepared_nolead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (8, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 8
+            },
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 8
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_complete_noprepared_lead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[
+            (SELF_PARTY, overridden),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal),
+            (9, overridden)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 9
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_complete_carryover() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, overridden)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_complete_carryover_commit() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (7, overridden),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_complete_carryover_complete() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (7, overridden),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_complete_decide_both() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (7, overridden),
+            (6, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_complete_decide_both_commit() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (7, overridden),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_complete_decide_both_complete() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (7, overridden),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Complete {
+                req: overridden,
+                party: 7
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_fail_noprepared_lead() {
+    let overridden = 0;
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (1, overridden),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal),
+            (7, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: overridden,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 7
+            },
+            ConsensusTestOp::Fail { party: 9 },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 7
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_fail_carryover() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Fail { party: 7 },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_fail_carryover_commit() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Fail { party: 7 },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_fail_carryover_complete() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 9
+            },
+            ConsensusTestOp::Fail { party: 7 },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_fail_decide_both() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (6, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Fail { party: 7 },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 6
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_fail_decide_both_commit() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Fail { party: 7 },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_finish_commit_override_fail_decide_both_complete() {
+    let proposal = 2;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            (SELF_PARTY, proposal),
+            (1, proposal),
+            (2, proposal),
+            (3, proposal),
+            (4, proposal),
+            (5, proposal),
+            (9, proposal)
+        ],
+        &[
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Prepare {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Fail { party: 7 },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 1
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 2
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 3
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 4
+            },
+            ConsensusTestOp::Commit {
+                req: proposal,
+                party: 5
+            },
+            ConsensusTestOp::Complete {
+                req: proposal,
+                party: 9
+            }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Complete { .. }
+            } => {}
+            _ => panic!("Expected complete state")
+        }
+    );
+}
+
+#[test]
+fn test_deadlock_commit_nolead() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (6, a)
+        ],
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, b),
+            (5, b),
+            (6, b),
+            (7, b)
+        ],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: a, party: 3 },
+            ConsensusTestOp::Commit { req: b, party: 4 },
+            ConsensusTestOp::Commit { req: b, party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 },
+            ConsensusTestOp::Commit { req: b, party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_deadlock_commit_selflead() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (6, a)
+        ],
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, b),
+            (5, b),
+            (6, b),
+            (7, b)
+        ],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: a, party: 3 },
+            ConsensusTestOp::Commit { req: b, party: 4 },
+            ConsensusTestOp::Commit { req: b, party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 },
+            ConsensusTestOp::Commit { req: b, party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_deadlock_commit_nonlead() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (6, a)
+        ],
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, b),
+            (5, b),
+            (6, b),
+            (7, b)
+        ],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: a, party: 3 },
+            ConsensusTestOp::Commit { req: b, party: 4 },
+            ConsensusTestOp::Commit { req: b, party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 },
+            ConsensusTestOp::Commit { req: b, party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_deadlock_commit_lead() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (6, a)
+        ],
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, b),
+            (5, b),
+            (6, b),
+            (7, b)
+        ],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: a, party: 3 },
+            ConsensusTestOp::Commit { req: b, party: 4 },
+            ConsensusTestOp::Commit { req: b, party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 },
+            ConsensusTestOp::Commit { req: b, party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_deadlock_commit_noprepared_nolead() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(1, a), (2, a), (3, a), (4, a), (5, a), (6, a), (7, a)],
+        &[
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, b),
+            (6, b),
+            (7, b),
+            (8, b)
+        ],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Prepare { req: a, party: 7 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: a, party: 3 },
+            ConsensusTestOp::Commit { req: a, party: 4 },
+            ConsensusTestOp::Commit { req: b, party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 },
+            ConsensusTestOp::Commit { req: b, party: 7 },
+            ConsensusTestOp::Commit { req: b, party: 8 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_deadlock_commit_noprepared_lead() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(1, a), (2, a), (3, a), (4, a), (5, a), (6, a), (7, a)],
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, b),
+            (4, b),
+            (5, b),
+            (6, b),
+            (9, a)
+        ],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Prepare { req: a, party: 7 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: b, party: 3 },
+            ConsensusTestOp::Commit { req: b, party: 4 },
+            ConsensusTestOp::Commit { req: b, party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 },
+            ConsensusTestOp::Commit { req: a, party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_deadlock_commit_carryover() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, b),
+            (5, b),
+            (6, b),
+            (7, b)
+        ],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 9 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: a, party: 3 },
+            ConsensusTestOp::Commit { req: b, party: 4 },
+            ConsensusTestOp::Commit { req: b, party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 },
+            ConsensusTestOp::Commit { req: b, party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_deadlock_commit_carryover_commit() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, b),
+            (4, b),
+            (5, b),
+            (6, b),
+            (9, a)
+        ],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Commit { req: a, party: 9 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: b, party: 3 },
+            ConsensusTestOp::Commit { req: b, party: 4 },
+            ConsensusTestOp::Commit { req: b, party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_deadlock_commit_carryover_complete() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, b),
+            (4, b),
+            (5, b),
+            (6, b),
+            (9, a)
+        ],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Complete { req: a, party: 9 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: b, party: 3 },
+            ConsensusTestOp::Commit { req: b, party: 4 },
+            ConsensusTestOp::Commit { req: b, party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_deadlock_commit_decide_both() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, b),
+            (5, b),
+            (6, b),
+            (7, b)
+        ],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: a, party: 3 },
+            ConsensusTestOp::Commit { req: b, party: 4 },
+            ConsensusTestOp::Commit { req: b, party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 },
+            ConsensusTestOp::Commit { req: b, party: 7 },
+            ConsensusTestOp::Prepare { req: a, party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_deadlock_commit_decide_both_commit() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, b),
+            (4, b),
+            (5, b),
+            (6, b),
+            (9, a)
+        ],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: b, party: 3 },
+            ConsensusTestOp::Commit { req: b, party: 4 },
+            ConsensusTestOp::Commit { req: b, party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 },
+            ConsensusTestOp::Commit { req: a, party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_deadlock_commit_decide_both_complete() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, b),
+            (4, b),
+            (5, b),
+            (6, b),
+            (9, a)
+        ],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: b, party: 3 },
+            ConsensusTestOp::Commit { req: b, party: 4 },
+            ConsensusTestOp::Commit { req: b, party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 },
+            ConsensusTestOp::Complete { req: a, party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_all_fail_commit_nolead() {
+    let a = 0;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (6, a)
+        ],
+        &[(SELF_PARTY, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_all_fail_commit_selflead() {
+    let a = 0;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (6, a)
+        ],
+        &[(SELF_PARTY, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_all_fail_commit_nonlead() {
+    let a = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (6, a)
+        ],
+        &[(SELF_PARTY, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_all_fail_commit_lead() {
+    let a = 0;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (6, a)
+        ],
+        &[(SELF_PARTY, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_all_fail_commit_noprepared_nolead() {
+    let a = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(1, a), (2, a), (3, a), (4, a), (5, a), (6, a), (7, a)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Prepare { req: a, party: 7 },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_all_fail_commit_noprepared_lead() {
+    let a = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(1, a), (2, a), (3, a), (4, a), (5, a), (6, a), (7, a)],
+        &[],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Prepare { req: a, party: 7 },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_all_fail_commit_carryover() {
+    let a = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[(SELF_PARTY, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 9 },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_all_fail_commit_carryover_commit() {
+    let a = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[(SELF_PARTY, a), (9, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Commit { req: a, party: 9 },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_all_fail_commit_carryover_complete() {
+    let a = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[(SELF_PARTY, a), (9, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Complete { req: a, party: 9 },
+            ConsensusTestOp::Fail { party: 1 },
+            ConsensusTestOp::Fail { party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_fail_commit_nolead() {
+    let a = 0;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (6, a)
+        ],
+        &[(SELF_PARTY, a), (1, a), (2, a), (3, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: a, party: 3 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Fail { party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_fail_commit_selflead() {
+    let a = 0;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (6, a)
+        ],
+        &[(SELF_PARTY, a), (1, a), (2, a), (3, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: a, party: 3 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Fail { party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_fail_commit_nonlead() {
+    let a = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (6, a)
+        ],
+        &[(SELF_PARTY, a), (1, a), (2, a), (3, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: a, party: 3 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Fail { party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_fail_commit_lead() {
+    let a = 0;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (6, a)
+        ],
+        &[(SELF_PARTY, a), (1, a), (2, a), (3, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: a, party: 3 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Fail { party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_fail_commit_noprepared_nolead() {
+    let a = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(1, a), (2, a), (3, a), (4, a), (5, a), (6, a), (7, a)],
+        &[(1, a), (2, a), (3, a), (4, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Prepare { req: a, party: 7 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: a, party: 3 },
+            ConsensusTestOp::Commit { req: a, party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Fail { party: 7 },
+            ConsensusTestOp::Fail { party: 8 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_fail_commit_noprepared_lead() {
+    let a = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(1, a), (2, a), (3, a), (4, a), (5, a), (6, a), (7, a)],
+        &[(SELF_PARTY, a), (1, a), (2, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Prepare { req: a, party: 7 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Fail { party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_fail_commit_carryover() {
+    let a = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[(SELF_PARTY, a), (1, a), (2, a), (3, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 9 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Commit { req: a, party: 3 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Fail { party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_fail_commit_carryover_commit() {
+    let a = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[(SELF_PARTY, a), (1, a), (2, a), (9, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Commit { req: a, party: 9 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Fail { party: 6 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_fail_commit_carryover_complete() {
+    let a = 0;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[(SELF_PARTY, a), (1, a), (2, a), (9, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Complete { req: a, party: 9 },
+            ConsensusTestOp::Commit { req: a, party: 1 },
+            ConsensusTestOp::Commit { req: a, party: 2 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Fail { party: 6 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_doomed_commit_nolead() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::None { hint: () };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (6, a)
+        ],
+        &[(SELF_PARTY, a), (7, b)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Commit { req: b, party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_doomed_commit_selflead() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::This;
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (6, a)
+        ],
+        &[(SELF_PARTY, a), (7, b)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Commit { req: b, party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_doomed_commit_nonlead() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (6, a)
+        ],
+        &[(SELF_PARTY, a), (7, b)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Commit { req: b, party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_doomed_commit_lead() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 1 };
+
+    consensus_test(
+        Some(a),
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (6, a)
+        ],
+        &[(SELF_PARTY, a), (7, b)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Commit { req: b, party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_doomed_commit_noprepared_nolead() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(1, a), (2, a), (3, a), (4, a), (5, a), (6, a), (7, a)],
+        &[(1, a), (8, b)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Prepare { req: a, party: 7 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Fail { party: 7 },
+            ConsensusTestOp::Commit { req: b, party: 8 },
+            ConsensusTestOp::Commit { req: a, party: 1 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_doomed_commit_noprepared_lead() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[(1, a), (2, a), (3, a), (4, a), (5, a), (6, a), (7, a)],
+        &[(SELF_PARTY, a), (6, b), (9, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 6 },
+            ConsensusTestOp::Prepare { req: a, party: 7 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 },
+            ConsensusTestOp::Commit { req: a, party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_doomed_commit_carryover() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[(SELF_PARTY, a), (7, b)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Prepare { req: a, party: 9 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Commit { req: b, party: 7 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_doomed_commit_carryover_commit() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[(SELF_PARTY, a), (6, b), (9, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Commit { req: a, party: 9 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_doomed_commit_carryover_complete() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[(SELF_PARTY, a), (6, b), (9, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Complete { req: a, party: 9 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_doomed_commit_decide_both() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[(SELF_PARTY, a), (7, b)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Fail { party: 6 },
+            ConsensusTestOp::Commit { req: b, party: 7 },
+            ConsensusTestOp::Prepare { req: a, party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_doomed_commit_decide_both_commit() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[(SELF_PARTY, a), (6, b), (9, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 },
+            ConsensusTestOp::Commit { req: a, party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}
+
+#[test]
+fn test_doomed_commit_decide_both_complete() {
+    let a = 0;
+    let b = 1;
+    let leader = PBFTLeader::Other { party: 9 };
+
+    consensus_test(
+        None,
+        &leader,
+        &[
+            (SELF_PARTY, a),
+            (1, a),
+            (2, a),
+            (3, a),
+            (4, a),
+            (5, a),
+            (9, a)
+        ],
+        &[(SELF_PARTY, a), (6, b), (9, a)],
+        &[
+            ConsensusTestOp::Prepare { req: a, party: 1 },
+            ConsensusTestOp::Prepare { req: a, party: 2 },
+            ConsensusTestOp::Prepare { req: a, party: 3 },
+            ConsensusTestOp::Prepare { req: a, party: 4 },
+            ConsensusTestOp::Prepare { req: a, party: 5 },
+            ConsensusTestOp::Fail { party: 3 },
+            ConsensusTestOp::Fail { party: 4 },
+            ConsensusTestOp::Fail { party: 5 },
+            ConsensusTestOp::Commit { req: b, party: 6 },
+            ConsensusTestOp::Complete { req: a, party: 9 }
+        ],
+        |update| match &update {
+            RoundStateUpdate::Resolved {
+                resolved: PBFTRoundResult::Fail { .. }
+            } => {}
+            _ => panic!("Expected fail state")
+        }
+    );
+}


### PR DESCRIPTION
Initial import of content:
* Add all content from JHU/APL repo source archive
* Add CI configurations
* Add `README.md` content
* Issue triage (replacing all XXX comments with issue numbers)